### PR TITLE
Issue #3: App Store レビュー誘導を導入

### DIFF
--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1DA7D67C578599E61615EB0A /* SoundSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67AB20F46B6C8D33B5653CA4 /* SoundSettingsSection.swift */; };
+		20AE081601A9F079317B73CF /* AboutSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE2E351DBFBBEAF8AE6EA6C /* AboutSettingsSection.swift */; };
 		2E2CB3CE983BECF622864400 /* Pods_LeafTimer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17C7491631569CCC5150105 /* Pods_LeafTimer.framework */; };
 		3818BC6424E38E5E0070C612 /* LocalUserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3818BC6324E38E5E0070C612 /* LocalUserDefaultWrapper.swift */; };
 		3818BC6624E3902F0070C612 /* TimerViewModel+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3818BC6524E3902F0070C612 /* TimerViewModel+extensions.swift */; };
@@ -145,6 +146,7 @@
 		D5D32D482EB811A900DECF70 /* bgm3.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm3.mp3; sourceTree = "<group>"; };
 		EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewRequestPolicySpec.swift; path = LeafTimerTests/ReviewRequestPolicySpec.swift; sourceTree = SOURCE_ROOT; };
 		FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitReviewRequester.swift; path = LeafTimer/Components/StoreKitReviewRequester.swift; sourceTree = SOURCE_ROOT; };
+		FFE2E351DBFBBEAF8AE6EA6C /* AboutSettingsSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AboutSettingsSection.swift; path = LeafTimer/View/Settings/AboutSettingsSection.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,6 +328,7 @@
 		91003DEF4FA4F6528C6FD637 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				FFE2E351DBFBBEAF8AE6EA6C /* AboutSettingsSection.swift */,
 				58052409AAA0F0D30423F06C /* ResetSettingsSection.swift */,
 				67AB20F46B6C8D33B5653CA4 /* SoundSettingsSection.swift */,
 				9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */,
@@ -669,6 +672,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20AE081601A9F079317B73CF /* AboutSettingsSection.swift in Sources */,
 				38C95EF325D7270D00D80736 /* AdsView.swift in Sources */,
 				3864B7CC2494D81D00948ACA /* AppDelegate.swift in Sources */,
 				3818BC6B24E6D5BB0070C612 /* Binding+extension.swift in Sources */,

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -37,10 +37,12 @@
 		38B7261C24DD85900098F3D4 /* GIFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B7261B24DD85900098F3D4 /* GIFView.swift */; };
 		38C95EF325D7270D00D80736 /* AdsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C95EF225D7270D00D80736 /* AdsView.swift */; };
 		38C95EF825D7326A00D80736 /* KeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C95EF725D7326A00D80736 /* KeyManager.swift */; };
+		515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */; };
 		582E23040FA8ED370FF6A7BC /* TimerSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */; };
 		62C32389E6A1D1E4CE7D17A9 /* Pods_LeafTimer_LeafTimerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8653E98698211081B54C46C8 /* Pods_LeafTimer_LeafTimerUITests.framework */; };
 		8FCEACFA0C364E12D6C2EA03 /* Pods_LeafTimerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */; };
 		93FFE81424FF1BE500AA1BD1 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FFE81324FF1BE500AA1BD1 /* DateManager.swift */; };
+		B41DECA1FAE3E49A1549CAC7 /* ReviewRequestPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */; };
 		C1407F93645BA5CB0A1B0A20 /* ModernSettingViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */; };
 		C62791E3329348905B6A5F87 /* EnhancedSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F34D2A812A6B1BF5AE66D6A /* EnhancedSettingView.swift */; };
 		D51DACE92E51C175006B8B3D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D51DACE82E51C175006B8B3D /* GoogleService-Info.plist */; };
@@ -76,6 +78,7 @@
 		051B521F216134FC418A5DB3 /* Pods-LeafTimer-LeafTimerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimer-LeafTimerUITests.release.xcconfig"; path = "Target Support Files/Pods-LeafTimer-LeafTimerUITests/Pods-LeafTimer-LeafTimerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernTimerViewSpec.swift; sourceTree = "<group>"; };
 		1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeafTimerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewRequestPolicy.swift; path = LeafTimer/Components/ReviewRequestPolicy.swift; sourceTree = SOURCE_ROOT; };
 		33EC14C8994F314F6C2F6C06 /* Pods-LeafTimer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimer.release.xcconfig"; path = "Target Support Files/Pods-LeafTimer/Pods-LeafTimer.release.xcconfig"; sourceTree = "<group>"; };
 		3818BC6324E38E5E0070C612 /* LocalUserDefaultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUserDefaultWrapper.swift; sourceTree = "<group>"; };
 		3818BC6524E3902F0070C612 /* TimerViewModel+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimerViewModel+extensions.swift"; sourceTree = "<group>"; };
@@ -133,6 +136,7 @@
 		D5D32D462EB811A900DECF70 /* bgm1.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm1.mp3; sourceTree = "<group>"; };
 		D5D32D472EB811A900DECF70 /* bgm2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm2.mp3; sourceTree = "<group>"; };
 		D5D32D482EB811A900DECF70 /* bgm3.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm3.mp3; sourceTree = "<group>"; };
+		EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewRequestPolicySpec.swift; path = LeafTimerTests/ReviewRequestPolicySpec.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +186,7 @@
 				3856FB8424AC1FE0007F40E5 /* DefaultTimerManager.swift */,
 				38C95EF725D7326A00D80736 /* KeyManager.swift */,
 				3818BC6324E38E5E0070C612 /* LocalUserDefaultWrapper.swift */,
+				33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */,
 				3818BC6C24EA4DA10070C612 /* UserDefaultItem.swift */,
 			);
 			path = Components;
@@ -289,6 +294,7 @@
 				3864B7E42494D82300948ACA /* Info.plist */,
 				C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */,
 				158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */,
+				EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */,
 				3865AB4A24CD3FFA001B03E4 /* SpyAudioManager.swift */,
 				3856FB7C24A8C714007F40E5 /* SpyTimerManager.swift */,
 				3864B7E22494D82300948ACA /* TimerViewSpec.swift */,
@@ -664,6 +670,7 @@
 				38C95EF825D7326A00D80736 /* KeyManager.swift in Sources */,
 				3818BC6424E38E5E0070C612 /* LocalUserDefaultWrapper.swift in Sources */,
 				F2B6E50A848C74D7C919E1B7 /* ResetSettingsSection.swift in Sources */,
+				B41DECA1FAE3E49A1549CAC7 /* ReviewRequestPolicy.swift in Sources */,
 				3865AB4524CD2272001B03E4 /* SettingView.swift in Sources */,
 				3818BC6924E392B60070C612 /* SettingViewModel.swift in Sources */,
 				1DA7D67C578599E61615EB0A /* SoundSettingsSection.swift in Sources */,
@@ -681,6 +688,7 @@
 			files = (
 				C1407F93645BA5CB0A1B0A20 /* ModernSettingViewSpec.swift in Sources */,
 				E5EE5B694F71609B83B26C7E /* ModernTimerViewSpec.swift in Sources */,
+				515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */,
 				3865AB4B24CD3FFA001B03E4 /* SpyAudioManager.swift in Sources */,
 				3856FB7D24A8C714007F40E5 /* SpyTimerManager.swift in Sources */,
 				3864B7E32494D82300948ACA /* TimerViewSpec.swift in Sources */,

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		582E23040FA8ED370FF6A7BC /* TimerSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */; };
 		62C32389E6A1D1E4CE7D17A9 /* Pods_LeafTimer_LeafTimerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8653E98698211081B54C46C8 /* Pods_LeafTimer_LeafTimerUITests.framework */; };
 		84666D3C498EACFC6A3B255B /* StoreKitReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */; };
+		8BA106ABCE3F785BD2F48DF9 /* MockReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8CE2A71E448553A13E434F /* MockReviewRequester.swift */; };
 		8FCEACFA0C364E12D6C2EA03 /* Pods_LeafTimerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */; };
 		93FFE81424FF1BE500AA1BD1 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FFE81324FF1BE500AA1BD1 /* DateManager.swift */; };
 		B41DECA1FAE3E49A1549CAC7 /* ReviewRequestPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */; };
@@ -115,6 +116,7 @@
 		38C95EF225D7270D00D80736 /* AdsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsView.swift; sourceTree = "<group>"; };
 		38C95EF725D7326A00D80736 /* KeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyManager.swift; sourceTree = "<group>"; };
 		39A8809BE7C4B0C55C3ED30D /* Pods-LeafTimer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimer.debug.xcconfig"; path = "Target Support Files/Pods-LeafTimer/Pods-LeafTimer.debug.xcconfig"; sourceTree = "<group>"; };
+		3A8CE2A71E448553A13E434F /* MockReviewRequester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockReviewRequester.swift; path = LeafTimerTests/MockReviewRequester.swift; sourceTree = SOURCE_ROOT; };
 		3FB3C2CFB16693878EE047AB /* Pods-LeafTimer-LeafTimerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimer-LeafTimerUITests.debug.xcconfig"; path = "Target Support Files/Pods-LeafTimer-LeafTimerUITests/Pods-LeafTimer-LeafTimerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		4EFC6603AA0440B7F2CBC328 /* Pods-LeafTimerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimerUITests.release.xcconfig"; path = "Target Support Files/Pods-LeafTimerUITests/Pods-LeafTimerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		54317E73F2F3BC94B2411A11 /* Pods-LeafTimerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimerTests.debug.xcconfig"; path = "Target Support Files/Pods-LeafTimerTests/Pods-LeafTimerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -295,6 +297,7 @@
 			isa = PBXGroup;
 			children = (
 				3864B7E42494D82300948ACA /* Info.plist */,
+				3A8CE2A71E448553A13E434F /* MockReviewRequester.swift */,
 				C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */,
 				158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */,
 				EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */,
@@ -690,6 +693,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BA106ABCE3F785BD2F48DF9 /* MockReviewRequester.swift in Sources */,
 				C1407F93645BA5CB0A1B0A20 /* ModernSettingViewSpec.swift in Sources */,
 				E5EE5B694F71609B83B26C7E /* ModernTimerViewSpec.swift in Sources */,
 				515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */,

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */; };
 		582E23040FA8ED370FF6A7BC /* TimerSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */; };
 		62C32389E6A1D1E4CE7D17A9 /* Pods_LeafTimer_LeafTimerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8653E98698211081B54C46C8 /* Pods_LeafTimer_LeafTimerUITests.framework */; };
+		84666D3C498EACFC6A3B255B /* StoreKitReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */; };
 		8FCEACFA0C364E12D6C2EA03 /* Pods_LeafTimerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */; };
 		93FFE81424FF1BE500AA1BD1 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FFE81324FF1BE500AA1BD1 /* DateManager.swift */; };
 		B41DECA1FAE3E49A1549CAC7 /* ReviewRequestPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */; };
@@ -137,6 +138,7 @@
 		D5D32D472EB811A900DECF70 /* bgm2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm2.mp3; sourceTree = "<group>"; };
 		D5D32D482EB811A900DECF70 /* bgm3.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bgm3.mp3; sourceTree = "<group>"; };
 		EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewRequestPolicySpec.swift; path = LeafTimerTests/ReviewRequestPolicySpec.swift; sourceTree = SOURCE_ROOT; };
+		FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitReviewRequester.swift; path = LeafTimer/Components/StoreKitReviewRequester.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +189,7 @@
 				38C95EF725D7326A00D80736 /* KeyManager.swift */,
 				3818BC6324E38E5E0070C612 /* LocalUserDefaultWrapper.swift */,
 				33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */,
+				FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */,
 				3818BC6C24EA4DA10070C612 /* UserDefaultItem.swift */,
 			);
 			path = Components;
@@ -674,6 +677,7 @@
 				3865AB4524CD2272001B03E4 /* SettingView.swift in Sources */,
 				3818BC6924E392B60070C612 /* SettingViewModel.swift in Sources */,
 				1DA7D67C578599E61615EB0A /* SoundSettingsSection.swift in Sources */,
+				84666D3C498EACFC6A3B255B /* StoreKitReviewRequester.swift in Sources */,
 				582E23040FA8ED370FF6A7BC /* TimerSettingsSection.swift in Sources */,
 				3864B7D02494D81D00948ACA /* TimerView.swift in Sources */,
 				3818BC6624E3902F0070C612 /* TimerViewModel+extensions.swift in Sources */,

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		38B7261C24DD85900098F3D4 /* GIFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B7261B24DD85900098F3D4 /* GIFView.swift */; };
 		38C95EF325D7270D00D80736 /* AdsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C95EF225D7270D00D80736 /* AdsView.swift */; };
 		38C95EF825D7326A00D80736 /* KeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C95EF725D7326A00D80736 /* KeyManager.swift */; };
+		50CF900C3AEE7EB0580402FA /* ReviewIntegrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E76F08701A5811DDED6A33 /* ReviewIntegrationSpec.swift */; };
 		515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */; };
 		582E23040FA8ED370FF6A7BC /* TimerSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */; };
 		62C32389E6A1D1E4CE7D17A9 /* Pods_LeafTimer_LeafTimerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8653E98698211081B54C46C8 /* Pods_LeafTimer_LeafTimerUITests.framework */; };
@@ -45,6 +46,7 @@
 		8FCEACFA0C364E12D6C2EA03 /* Pods_LeafTimerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */; };
 		93FFE81424FF1BE500AA1BD1 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FFE81324FF1BE500AA1BD1 /* DateManager.swift */; };
 		B41DECA1FAE3E49A1549CAC7 /* ReviewRequestPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AD9A46E6707A632F42258D /* ReviewRequestPolicy.swift */; };
+		B70E83FDCE085D30BF9E8703 /* MockUserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B135F8247048DD2B815AA60A /* MockUserDefaultWrapper.swift */; };
 		C1407F93645BA5CB0A1B0A20 /* ModernSettingViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */; };
 		C62791E3329348905B6A5F87 /* EnhancedSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F34D2A812A6B1BF5AE66D6A /* EnhancedSettingView.swift */; };
 		D51DACE92E51C175006B8B3D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D51DACE82E51C175006B8B3D /* GoogleService-Info.plist */; };
@@ -129,6 +131,8 @@
 		93FFE81324FF1BE500AA1BD1 /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
 		9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSettingsSection.swift; sourceTree = "<group>"; };
 		A17C7491631569CCC5150105 /* Pods_LeafTimer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeafTimer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5E76F08701A5811DDED6A33 /* ReviewIntegrationSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewIntegrationSpec.swift; path = LeafTimerTests/ReviewIntegrationSpec.swift; sourceTree = SOURCE_ROOT; };
+		B135F8247048DD2B815AA60A /* MockUserDefaultWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockUserDefaultWrapper.swift; path = LeafTimerTests/MockUserDefaultWrapper.swift; sourceTree = SOURCE_ROOT; };
 		C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernSettingViewSpec.swift; sourceTree = "<group>"; };
 		D51DACE82E51C175006B8B3D /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D51DACEA2E51C437006B8B3D /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
@@ -298,8 +302,10 @@
 			children = (
 				3864B7E42494D82300948ACA /* Info.plist */,
 				3A8CE2A71E448553A13E434F /* MockReviewRequester.swift */,
+				B135F8247048DD2B815AA60A /* MockUserDefaultWrapper.swift */,
 				C8CB59B9BEDD027B3A0A624A /* ModernSettingViewSpec.swift */,
 				158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */,
+				A5E76F08701A5811DDED6A33 /* ReviewIntegrationSpec.swift */,
 				EA977BF9073A2CCBD947391F /* ReviewRequestPolicySpec.swift */,
 				3865AB4A24CD3FFA001B03E4 /* SpyAudioManager.swift */,
 				3856FB7C24A8C714007F40E5 /* SpyTimerManager.swift */,
@@ -694,8 +700,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BA106ABCE3F785BD2F48DF9 /* MockReviewRequester.swift in Sources */,
+				B70E83FDCE085D30BF9E8703 /* MockUserDefaultWrapper.swift in Sources */,
 				C1407F93645BA5CB0A1B0A20 /* ModernSettingViewSpec.swift in Sources */,
 				E5EE5B694F71609B83B26C7E /* ModernTimerViewSpec.swift in Sources */,
+				50CF900C3AEE7EB0580402FA /* ReviewIntegrationSpec.swift in Sources */,
 				515A801883C4B7E486578D92 /* ReviewRequestPolicySpec.swift in Sources */,
 				3865AB4B24CD3FFA001B03E4 /* SpyAudioManager.swift in Sources */,
 				3856FB7D24A8C714007F40E5 /* SpyTimerManager.swift in Sources */,

--- a/app/LeafTimer/App/en.lproj/Localizable.strings
+++ b/app/LeafTimer/App/en.lproj/Localizable.strings
@@ -54,3 +54,8 @@
 "button.start" = "START";
 "button.stop" = "STOP";
 
+// MARK: - About / Review
+"settings.about_section" = "About";
+"settings.review_app" = "Review this app";
+"settings.review_app_footer" = "If you enjoy LeafTimer, please leave a review on the App Store.";
+

--- a/app/LeafTimer/App/ja.lproj/Localizable.strings
+++ b/app/LeafTimer/App/ja.lproj/Localizable.strings
@@ -54,3 +54,8 @@
 // MARK: - Button Labels
 "button.start" = "START";
 "button.stop" = "STOP";
+
+// MARK: - About / Review
+"settings.about_section" = "アプリについて";
+"settings.review_app" = "このアプリを評価する";
+"settings.review_app_footer" = "LeafTimer が役に立ったら、App Store でレビューをお寄せください。";

--- a/app/LeafTimer/Components/ReviewRequestPolicy.swift
+++ b/app/LeafTimer/Components/ReviewRequestPolicy.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+protocol ReviewRequestPolicy {
+    func shouldRequest(totalCount: Int, lastRequestedCount: Int) -> Bool
+}
+
+struct ThresholdReviewRequestPolicy: ReviewRequestPolicy {
+    static let thresholds = [5, 20, 50]
+
+    func shouldRequest(totalCount: Int, lastRequestedCount: Int) -> Bool {
+        Self.thresholds.contains { threshold in
+            lastRequestedCount < threshold && totalCount >= threshold
+        }
+    }
+}

--- a/app/LeafTimer/Components/StoreKitReviewRequester.swift
+++ b/app/LeafTimer/Components/StoreKitReviewRequester.swift
@@ -1,0 +1,27 @@
+import Foundation
+import StoreKit
+import UIKit
+
+protocol ReviewRequesting {
+    func requestReview()
+    func openAppStoreReviewPage()
+}
+
+final class StoreKitReviewRequester: ReviewRequesting {
+    func requestReview() {
+        guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
+            return
+        }
+        SKStoreReviewController.requestReview(in: scene)
+    }
+
+    func openAppStoreReviewPage() {
+        guard let appID = Bundle.main.object(forInfoDictionaryKey: "LeafTimerAppStoreID") as? String,
+              !appID.isEmpty,
+              let url = URL(string: "https://apps.apple.com/app/id\(appID)?action=write-review") else {
+            return
+        }
+        UIApplication.shared.open(url)
+    }
+}

--- a/app/LeafTimer/Components/UserDefaultItem.swift
+++ b/app/LeafTimer/Components/UserDefaultItem.swift
@@ -7,6 +7,9 @@ enum UserDefaultItem: String {
 
     case workingSound
     case breakSound
+
+    case totalPomodoroCount
+    case lastReviewRequestedCount
 }
 
 enum ItemValue {

--- a/app/LeafTimer/View/EnhancedSettingView.swift
+++ b/app/LeafTimer/View/EnhancedSettingView.swift
@@ -44,6 +44,9 @@ struct EnhancedSettingView: View {
                         .foregroundColor(.secondary)
                 }
 
+                // About Section
+                AboutSettingsSection(viewModel: settingViewModel)
+
                 // Reset & System Section
                 ResetSettingsSection(viewModel: settingViewModel)
                 

--- a/app/LeafTimer/View/Settings/AboutSettingsSection.swift
+++ b/app/LeafTimer/View/Settings/AboutSettingsSection.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct AboutSettingsSection: View {
+    @ObservedObject var viewModel: SettingViewModel
+
+    var body: some View {
+        Section {
+            Button {
+                viewModel.openAppStoreReviewPage()
+            } label: {
+                HStack {
+                    Label(
+                        NSLocalizedString("settings.review_app", comment: "Review this app"),
+                        systemImage: "star.fill"
+                    )
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.primary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 8)
+            }
+        } header: {
+            HStack {
+                Image(systemName: "star.circle.fill")
+                    .foregroundColor(.yellow)
+                Text(NSLocalizedString("settings.about_section", comment: "About section header"))
+            }
+            .font(.system(size: 13, weight: .semibold))
+            .textCase(.uppercase)
+        } footer: {
+            Text(NSLocalizedString(
+                "settings.review_app_footer",
+                comment: "Footer for review section"
+            ))
+            .font(.system(size: 11))
+            .foregroundColor(.secondary)
+        }
+    }
+}

--- a/app/LeafTimer/ViewModel/SettingViewModel.swift
+++ b/app/LeafTimer/ViewModel/SettingViewModel.swift
@@ -5,6 +5,7 @@ class SettingViewModel: ObservableObject {
     // MARK: - Dependency Injection
 
     var userDefaultWrapper: UserDefaultsWrapper
+    var reviewRequester: ReviewRequesting
 
     // MARK: - Observed Parameter
 
@@ -26,8 +27,16 @@ class SettingViewModel: ObservableObject {
 
     // MARK: - Initialization
 
-    init(userDefaultWrapper: UserDefaultsWrapper) {
+    init(
+        userDefaultWrapper: UserDefaultsWrapper,
+        reviewRequester: ReviewRequesting = StoreKitReviewRequester()
+    ) {
         self.userDefaultWrapper = userDefaultWrapper
+        self.reviewRequester = reviewRequester
+    }
+
+    func openAppStoreReviewPage() {
+        reviewRequester.openAppStoreReviewPage()
     }
 
     func write(selected: Int, item: String) {

--- a/app/LeafTimer/ViewModel/TimerViewModel.swift
+++ b/app/LeafTimer/ViewModel/TimerViewModel.swift
@@ -7,6 +7,8 @@ class TimerViewModel: ObservableObject {
     var timerManager: TimerManager
     var audioManager: AudioManager
     var userDefaultWrapper: UserDefaultsWrapper
+    var reviewPolicy: ReviewRequestPolicy
+    var reviewRequester: ReviewRequesting
 
     // MARK: - Observed Parameter
 
@@ -34,11 +36,15 @@ class TimerViewModel: ObservableObject {
     init(
         timerManager: TimerManager,
         audioManager: AudioManager,
-        userDefaultWrapper: UserDefaultsWrapper
+        userDefaultWrapper: UserDefaultsWrapper,
+        reviewPolicy: ReviewRequestPolicy = ThresholdReviewRequestPolicy(),
+        reviewRequester: ReviewRequesting = StoreKitReviewRequester()
     ) {
         self.timerManager = timerManager
         self.audioManager = audioManager
         self.userDefaultWrapper = userDefaultWrapper
+        self.reviewPolicy = reviewPolicy
+        self.reviewRequester = reviewRequester
 
         fullTimeSecond = 25 * 60
         currentTimeSecond = 25 * 60
@@ -155,6 +161,31 @@ class TimerViewModel: ObservableObject {
     func countWork() {
         todaysCount += 1
         userDefaultWrapper.saveData(key: DateManager.getToday(), value: todaysCount)
+
+        let totalCount = userDefaultWrapper.loadData(
+            key: UserDefaultItem.totalPomodoroCount.rawValue
+        ) + 1
+        userDefaultWrapper.saveData(
+            key: UserDefaultItem.totalPomodoroCount.rawValue,
+            value: totalCount
+        )
+
+        requestReviewIfNeeded(totalCount: totalCount)
+    }
+
+    private func requestReviewIfNeeded(totalCount: Int) {
+        let lastRequested: Int = userDefaultWrapper.loadData(
+            key: UserDefaultItem.lastReviewRequestedCount.rawValue
+        )
+        guard reviewPolicy.shouldRequest(
+            totalCount: totalCount, lastRequestedCount: lastRequested
+        ) else { return }
+
+        reviewRequester.requestReview()
+        userDefaultWrapper.saveData(
+            key: UserDefaultItem.lastReviewRequestedCount.rawValue,
+            value: totalCount
+        )
     }
 
     func loadCount() {

--- a/app/LeafTimerTests/MockReviewRequester.swift
+++ b/app/LeafTimerTests/MockReviewRequester.swift
@@ -1,12 +1,8 @@
 @testable import LeafTimer
 
 class MockReviewRequester: ReviewRequesting {
-    // MARK: - Call Tracking
-
     private(set) var requestReviewCallCount = 0
     private(set) var openAppStoreReviewPageCallCount = 0
-
-    // MARK: - ReviewRequesting Implementation
 
     func requestReview() {
         requestReviewCallCount += 1
@@ -15,8 +11,6 @@ class MockReviewRequester: ReviewRequesting {
     func openAppStoreReviewPage() {
         openAppStoreReviewPageCallCount += 1
     }
-
-    // MARK: - Helper Methods for Testing
 
     func reset() {
         requestReviewCallCount = 0

--- a/app/LeafTimerTests/MockReviewRequester.swift
+++ b/app/LeafTimerTests/MockReviewRequester.swift
@@ -1,0 +1,25 @@
+@testable import LeafTimer
+
+class MockReviewRequester: ReviewRequesting {
+    // MARK: - Call Tracking
+
+    private(set) var requestReviewCallCount = 0
+    private(set) var openAppStoreReviewPageCallCount = 0
+
+    // MARK: - ReviewRequesting Implementation
+
+    func requestReview() {
+        requestReviewCallCount += 1
+    }
+
+    func openAppStoreReviewPage() {
+        openAppStoreReviewPageCallCount += 1
+    }
+
+    // MARK: - Helper Methods for Testing
+
+    func reset() {
+        requestReviewCallCount = 0
+        openAppStoreReviewPageCallCount = 0
+    }
+}

--- a/app/LeafTimerTests/ReviewIntegrationSpec.swift
+++ b/app/LeafTimerTests/ReviewIntegrationSpec.swift
@@ -1,0 +1,118 @@
+import Quick
+import Nimble
+
+@testable import LeafTimer
+
+class ReviewIntegrationSpec: QuickSpec {
+    override class func spec() {
+        describe("TimerViewModel review request integration") {
+            it("does not request review when totalPomodoroCount stays under the first threshold") {
+                let spyTimerManager = SpyTimerManager()
+                let spyAudioManager = SpyAudioManager()
+                let mockUserDefaultWrapper = MockUserDefaultWrapper()
+                let mockReviewRequester = MockReviewRequester()
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.totalPomodoroCount.rawValue, value: 3
+                )
+                let timerViewModel = TimerViewModel(
+                    timerManager: spyTimerManager,
+                    audioManager: spyAudioManager,
+                    userDefaultWrapper: mockUserDefaultWrapper,
+                    reviewPolicy: ThresholdReviewRequestPolicy(),
+                    reviewRequester: mockReviewRequester
+                )
+
+                // When: ワーク完了 (3 → 4)
+                timerViewModel.breakState = false
+                timerViewModel.switchBreakState()
+
+                // Then
+                expect(mockReviewRequester.requestReviewCallCount) == 0
+            }
+
+            it("requests review when totalPomodoroCount crosses the first threshold (4 -> 5)") {
+                let spyTimerManager = SpyTimerManager()
+                let spyAudioManager = SpyAudioManager()
+                let mockUserDefaultWrapper = MockUserDefaultWrapper()
+                let mockReviewRequester = MockReviewRequester()
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.totalPomodoroCount.rawValue, value: 4
+                )
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.lastReviewRequestedCount.rawValue, value: 0
+                )
+                let timerViewModel = TimerViewModel(
+                    timerManager: spyTimerManager,
+                    audioManager: spyAudioManager,
+                    userDefaultWrapper: mockUserDefaultWrapper,
+                    reviewPolicy: ThresholdReviewRequestPolicy(),
+                    reviewRequester: mockReviewRequester
+                )
+
+                // When: ワーク完了 (4 → 5)
+                timerViewModel.breakState = false
+                timerViewModel.switchBreakState()
+
+                // Then
+                expect(mockReviewRequester.requestReviewCallCount) == 1
+            }
+
+            it("does not request review again on subsequent pomodoros within the same threshold range (5 -> 6)") {
+                let spyTimerManager = SpyTimerManager()
+                let spyAudioManager = SpyAudioManager()
+                let mockUserDefaultWrapper = MockUserDefaultWrapper()
+                let mockReviewRequester = MockReviewRequester()
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.totalPomodoroCount.rawValue, value: 5
+                )
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.lastReviewRequestedCount.rawValue, value: 5
+                )
+                let timerViewModel = TimerViewModel(
+                    timerManager: spyTimerManager,
+                    audioManager: spyAudioManager,
+                    userDefaultWrapper: mockUserDefaultWrapper,
+                    reviewPolicy: ThresholdReviewRequestPolicy(),
+                    reviewRequester: mockReviewRequester
+                )
+
+                // When: ワーク完了 (5 → 6)
+                timerViewModel.breakState = false
+                timerViewModel.switchBreakState()
+
+                // Then
+                expect(mockReviewRequester.requestReviewCallCount) == 0
+            }
+
+            it("updates lastReviewRequestedCount after requesting a review") {
+                let spyTimerManager = SpyTimerManager()
+                let spyAudioManager = SpyAudioManager()
+                let mockUserDefaultWrapper = MockUserDefaultWrapper()
+                let mockReviewRequester = MockReviewRequester()
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.totalPomodoroCount.rawValue, value: 4
+                )
+                mockUserDefaultWrapper.setValue(
+                    for: UserDefaultItem.lastReviewRequestedCount.rawValue, value: 0
+                )
+                let timerViewModel = TimerViewModel(
+                    timerManager: spyTimerManager,
+                    audioManager: spyAudioManager,
+                    userDefaultWrapper: mockUserDefaultWrapper,
+                    reviewPolicy: ThresholdReviewRequestPolicy(),
+                    reviewRequester: mockReviewRequester
+                )
+
+                // When: ワーク完了 (4 → 5)
+                timerViewModel.breakState = false
+                timerViewModel.switchBreakState()
+
+                // Then: lastReviewRequestedCount が 5 に更新されている
+                let saved: Int = mockUserDefaultWrapper.loadData(
+                    key: UserDefaultItem.lastReviewRequestedCount.rawValue
+                )
+                expect(saved) == 5
+            }
+        }
+    }
+}

--- a/app/LeafTimerTests/ReviewIntegrationSpec.swift
+++ b/app/LeafTimerTests/ReviewIntegrationSpec.swift
@@ -4,6 +4,7 @@ import Nimble
 @testable import LeafTimer
 
 class ReviewIntegrationSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
     override class func spec() {
         describe("TimerViewModel review request integration") {
             it("does not request review when totalPomodoroCount stays under the first threshold") {

--- a/app/LeafTimerTests/ReviewRequestPolicySpec.swift
+++ b/app/LeafTimerTests/ReviewRequestPolicySpec.swift
@@ -1,0 +1,54 @@
+import Quick
+import Nimble
+
+@testable import LeafTimer
+
+class ReviewRequestPolicySpec: QuickSpec {
+    override class func spec() {
+        describe("ThresholdReviewRequestPolicy") {
+            let policy = ThresholdReviewRequestPolicy()
+
+            context("when total has not crossed any threshold") {
+                it("returns false at total=4, last=0") {
+                    expect(policy.shouldRequest(totalCount: 4, lastRequestedCount: 0)) == false
+                }
+            }
+
+            context("when total just crosses the first threshold (5)") {
+                it("returns true at total=5, last=0") {
+                    expect(policy.shouldRequest(totalCount: 5, lastRequestedCount: 0)) == true
+                }
+            }
+
+            context("when total is at the threshold but already requested") {
+                it("returns false at total=5, last=5") {
+                    expect(policy.shouldRequest(totalCount: 5, lastRequestedCount: 5)) == false
+                }
+            }
+
+            context("when total crosses the second threshold (20)") {
+                it("returns true at total=20, last=5") {
+                    expect(policy.shouldRequest(totalCount: 20, lastRequestedCount: 5)) == true
+                }
+                it("returns false at total=20, last=20") {
+                    expect(policy.shouldRequest(totalCount: 20, lastRequestedCount: 20)) == false
+                }
+            }
+
+            context("when total skips multiple thresholds in one update") {
+                it("returns true at total=50, last=5") {
+                    expect(policy.shouldRequest(totalCount: 50, lastRequestedCount: 5)) == true
+                }
+            }
+
+            context("when total exceeds the last threshold") {
+                it("returns false at total=51, last=50") {
+                    expect(policy.shouldRequest(totalCount: 51, lastRequestedCount: 50)) == false
+                }
+                it("returns false at total=1000, last=50") {
+                    expect(policy.shouldRequest(totalCount: 1000, lastRequestedCount: 50)) == false
+                }
+            }
+        }
+    }
+}

--- a/app/bin/add-to-target.rb
+++ b/app/bin/add-to-target.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# Add a Swift file reference into a Xcode project group and attach it to a target.
+# Usage: add-to-target.rb <project_path> <file_path> <target_name> <group_path>
+#   project_path : path to .xcodeproj (e.g. LeafTimer.xcodeproj)
+#   file_path    : project-relative file path (e.g. LeafTimer/Components/Foo.swift)
+#   target_name  : Xcode target (e.g. LeafTimer or LeafTimerTests)
+#   group_path   : project-relative group path (e.g. LeafTimer/Components)
+# Idempotent: re-running is a no-op if the file is already attached to the target.
+
+require 'xcodeproj'
+
+abort "usage: add-to-target.rb <project> <file> <target> <group>" if ARGV.length != 4
+proj_path, file_path, target_name, group_path = ARGV
+
+project = Xcodeproj::Project.open(proj_path)
+target = project.targets.find { |t| t.name == target_name }
+abort "target not found: #{target_name}" unless target
+
+group = project.main_group.find_subpath(group_path, true)
+group.set_source_tree('SOURCE_ROOT') if group.source_tree.nil? || group.source_tree.empty?
+
+basename = File.basename(file_path)
+ref = group.files.find { |f| f.path == basename || f.path == file_path }
+
+if ref.nil?
+  ref = group.new_reference(file_path)
+  ref.source_tree = 'SOURCE_ROOT'
+end
+
+already_in_target = target.source_build_phase.files.any? { |bf| bf.file_ref == ref }
+if already_in_target
+  puts "no-op: #{file_path} already attached to #{target_name}"
+else
+  target.add_file_references([ref])
+  puts "added: #{file_path} -> #{target_name}"
+end
+
+project.save


### PR DESCRIPTION
## Summary

累計ポモドーロ完了が 5/20/50 回を跨いだ瞬間 (ワーク完了→ブレイク突入直後) にネイティブのレビュー要請ダイアログを出し、設定画面に手動の「アプリを評価する」導線も追加する。

設計と実装計画は事前にコミット済み:
- 設計: `docs/superpowers/specs/2026-05-12-app-store-review-prompt-design.md`
- 実装計画: `docs/superpowers/plans/2026-05-12-app-store-review-prompt.md`

## 変更点

- `ReviewRequestPolicy` (純粋ロジック) + `ReviewRequesting` protocol + `StoreKitReviewRequester` (副作用ラッパ) の3層分離
- `TimerViewModel.countWork()` で `totalPomodoroCount` を increment し閾値を跨いだ瞬間だけ `requestReview()` を呼ぶ。`lastReviewRequestedCount` で多重発火を防止
- 設定画面 (`EnhancedSettingView`) に `AboutSettingsSection` を追加し「アプリを評価する」を Reset セクションの直前に配置
- Localization (ja / en) に3キー追加
- `bin/add-to-target.rb`: pbxproj に file reference を機械的に追加するヘルパー (Tasks 1/3/4/6 で再利用)

## 計画外で対応したこと

- `MockUserDefaultWrapper.swift` が pbxproj に未登録だったため test target に登録
- `TimerCoreLogicSpec.swift` も pbxproj 未登録だったが、未解決のシンボル参照 (`switchToBreakMode` 等) があり別件のため**触っていない** (issue を立てる候補)
- シミュレータ destination は Makefile の `iPhone 17, OS=latest` に統一 (計画は `iPhone 16 Pro, OS=18.5` だったが未利用)

## テスト結果

- `make tests`: **Executed 58 tests, with 26 tests skipped and 0 failures (0 unexpected)** ✅
  - `ReviewRequestPolicySpec`: 8件 (境界値テスト) すべて pass
  - `ReviewIntegrationSpec`: 4件 (TimerViewModel 統合) すべて pass
- `make lint`: 178 violations, 0 serious (元 177 → +1 は `AboutSettingsSection` の `@ObservedObject` を既存 `SoundSettingsSection` と同 same-line pattern に揃えた選択)

## マージ後 / リリース前にやること

- [ ] 実機 or TestFlight でレビュー要請ダイアログが実際に表示されることを確認
  - シミュレータでは `SKStoreReviewController` は no-op
- [ ] App Store ID 確定後、`Info.plist` に `LeafTimerAppStoreID` キーを追加して設定画面の「アプリを評価する」ボタンが App Store URL を開くことを確認
- [ ] Issue #3 をクローズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)