### PR TITLE
Issue #17: SwiftLint 設定整備 (mark_format / blanket_disable / nimble_operator)

### DIFF
--- a/app/.swiftlint.yml
+++ b/app/.swiftlint.yml
@@ -229,13 +229,15 @@ vertical_whitespace:
 # Custom rules for LeafTimer project
 custom_rules:
   
-  # MARK comments should follow specific format
+  # MARK comments should follow Title Case (// MARK: - TitleCase ...)
+  # Fires only when a lowercase Latin letter follows "// MARK: - ".
+  # Japanese MARKs (e.g. "// MARK: - 永続化") are allowed (no match).
   mark_format:
     name: "MARK Format"
-    regex: "// MARK: - [A-Z]"
+    regex: "// MARK: - [a-z]"
     match_kinds:
       - comment
-    message: "MARK comments should follow '// MARK: - Title' format"
+    message: "MARK comments should follow '// MARK: - Title' format (Title Case required)"
     severity: warning
   
   # Prefer modern async/await where applicable

--- a/app/.swiftlint.yml
+++ b/app/.swiftlint.yml
@@ -56,7 +56,6 @@ opt_in_rules:
   - legacy_random
   - literal_expression_end_indentation
   - modifier_order
-  - nimble_operator
   - number_separator
   - object_literal
   - operator_usage_whitespace
@@ -130,6 +129,7 @@ disabled_rules:
   - force_try
   - todo
   - comment_spacing  # Allow Japanese comments
+  - nimble_operator  # Prefer BDD-style matchers (beNil/equal/beGreaterThan) over operators
 
 # Rule configurations
 attributes:

--- a/app/LeafTimer/ViewModel/TimerViewModel.swift
+++ b/app/LeafTimer/ViewModel/TimerViewModel.swift
@@ -67,7 +67,7 @@ class TimerViewModel: ObservableObject {
         }
     }
 
-    // MARK: - methods
+    // MARK: - Methods
 
     func onPressedTimerButton() {
         switch executeState {

--- a/app/LeafTimerTests/AudioSystemVerificationTests.swift
+++ b/app/LeafTimerTests/AudioSystemVerificationTests.swift
@@ -173,6 +173,7 @@ class AudioSystemVerificationTests: XCTestCase {
         XCTAssertNoThrow(audioManager.finish(), "Should handle rapid operations")
     }
 
+    // swiftlint:disable:next mark_format
     // MARK: - iOS 17 最適化機能テスト
 
     func testBatteryOptimizedAudioSession() {

--- a/app/LeafTimerTests/AudioSystemVerificationTests.swift
+++ b/app/LeafTimerTests/AudioSystemVerificationTests.swift
@@ -67,7 +67,6 @@ class AudioSystemVerificationTests: XCTestCase {
         XCTAssertNoThrow(audioManager.vibration(), "Vibration should trigger without errors")
     }
 
-    // swiftlint:disable:next mark_format
     // MARK: - Audio Sessionの適切な設定確認
 
     func testAudioSessionConfiguration() {

--- a/app/LeafTimerTests/DataPersistenceTests.swift
+++ b/app/LeafTimerTests/DataPersistenceTests.swift
@@ -34,8 +34,6 @@ class DataPersistenceTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    // .swiftlint.yml の mark_format 正規表現がバグっており Title Case MARK を誤検知するため抑制。
-    // swiftlint:disable:next mark_format
     // MARK: - UserDefaults保存・読み込みテスト
 
     func testSaveAndLoadIntegerValues() {
@@ -350,8 +348,6 @@ class DataPersistenceTests: XCTestCase {
         XCTAssertEqual(finalActualValue, finalExpectedValue, "Final value should be correct")
     }
 
-    // .swiftlint.yml の mark_format 正規表現がバグっており Title Case MARK を誤検知するため抑制。
-    // swiftlint:disable:next mark_format
     // MARK: - Edge Cases and Error Handling
 
     func testEmptyStringKeys() {
@@ -417,8 +413,6 @@ class DataPersistenceTests: XCTestCase {
         XCTAssertNoThrow(userDefaultsWrapper.loadData(key: testKey) as Int)
     }
 
-    // .swiftlint.yml の mark_format 正規表現がバグっており Title Case MARK を誤検知するため抑制。
-    // swiftlint:disable:next mark_format
     // MARK: - Mock Wrapper Testing
 
     func testMockWrapperFunctionality() {

--- a/app/LeafTimerTests/ModernSettingViewSpec.swift
+++ b/app/LeafTimerTests/ModernSettingViewSpec.swift
@@ -6,7 +6,7 @@ import SwiftUI
 @testable import LeafTimer
 
 class ModernSettingViewSpec: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override class func spec() {
         describe("Enhanced SettingView") {
             var settingView: SettingView!

--- a/app/LeafTimerTests/ModernTimerViewSpec.swift
+++ b/app/LeafTimerTests/ModernTimerViewSpec.swift
@@ -6,7 +6,7 @@ import SwiftUI
 @testable import LeafTimer
 
 class ModernTimerViewSpec: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override class func spec() {
         xdescribe("Modernized TimerView") {
             var timerView: TimerView!

--- a/app/LeafTimerTests/TimerCoreLogicSpec.swift
+++ b/app/LeafTimerTests/TimerCoreLogicSpec.swift
@@ -9,8 +9,8 @@ import SwiftUI
 // PR #14 (Issue #3) 時点で pbxproj 未登録のまま放置されていたものを、
 // Issue #15 で現 API (fullTimeSecond / switchBreakState / finishCallCount)
 // に書き直して復活させた。
-// swiftlint:disable function_body_length
 class TimerCoreLogicSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
     override class func spec() {
         describe("Timer Core Logic") {
 

--- a/docs/superpowers/plans/2026-05-22-issue-17-swiftlint-cleanup.md
+++ b/docs/superpowers/plans/2026-05-22-issue-17-swiftlint-cleanup.md
@@ -1,0 +1,472 @@
+# Issue #17 SwiftLint 整備 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.swiftlint.yml` の 3 つの欠陥 (mark_format 逆 regex / blanket_disable_command と Quick spec の衝突 / nimble_operator の matcher 形拒否) を本格対応で解消し、`swiftlint lint` の警告総数を 152 → 大幅減 (mark_format / blanket_disable_command / nimble_operator 由来 0 件) にする。
+
+**Architecture:**
+- `.swiftlint.yml` 編集中心 (3 ヶ所): custom rule `mark_format` の正規表現反転 / opt_in `nimble_operator` を `disabled_rules` 側に移動。
+- spec ファイル 3 件で `swiftlint:disable function_body_length` (blanket) を `swiftlint:disable:next function_body_length` に変換し、既存 ReviewIntegrationSpec パターンに揃える。
+- Issue #15 で workaround として追加した `swiftlint:disable:next mark_format` 4 ヶ所を削除し、本格対応で吸収。
+- baseline (152 warnings) と after の警告数を必ず計測し、PR 説明に載せる。
+
+**Tech Stack:** SwiftLint 0.60.0 / Quick / Nimble / CocoaPods.
+
+---
+
+## File Structure
+
+| ファイル | 種類 | 責務 |
+| --- | --- | --- |
+| `app/.swiftlint.yml` | 修正 | `mark_format.regex` 反転、`nimble_operator` を opt_in から除外し disabled_rules に追加 |
+| `app/LeafTimerTests/ModernTimerViewSpec.swift` | 修正 | L9 blanket disable を `disable:next` 化し `override class func spec()` 直前に配置 |
+| `app/LeafTimerTests/ModernSettingViewSpec.swift` | 修正 | L9 blanket disable を `disable:next` 化 |
+| `app/LeafTimerTests/TimerCoreLogicSpec.swift` | 修正 | L12 blanket disable を `disable:next` 化 |
+| `app/LeafTimerTests/DataPersistenceTests.swift` | 修正 | L38/L354/L421 の `disable:next mark_format` 削除 (workaround 吸収) |
+| `app/LeafTimerTests/AudioSystemVerificationTests.swift` | 修正 | L70 の `disable:next mark_format` 削除 |
+
+---
+
+## Task 1: ベースライン計測 (warning 数の事前記録)
+
+**Files:**
+- 編集なし (計測のみ)
+
+- [ ] **Step 1: 現状の警告総数を記録**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep -cE "warning|error"
+```
+
+Expected: `152` (現時点) — この数値を控えておく。
+
+- [ ] **Step 2: ルール別の内訳を記録**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep -oE "\(([a-z_]+)\)$" | sort | uniq -c | sort -rn
+```
+
+Expected: `mark_format`, `blanket_disable_command`, `nimble_operator` の各カウントを控えておく (PR 説明に使用)。
+
+---
+
+## Task 2: `.swiftlint.yml` の mark_format 正規表現を反転
+
+**Files:**
+- Modify: `app/.swiftlint.yml:233-239`
+
+**背景:** 現状 `regex: "// MARK: - [A-Z]"` は「Title Case にマッチしたら violation」と読まれるため、自然な Title Case (`// MARK: - Foo`) が全て warning。意図は逆 (Title Case を要求) なので、regex を「lowercase が来たら violation」に反転する。日本語 MARK (`// MARK: - 永続化`) は `[a-z]` にマッチしないので OK のまま。
+
+- [ ] **Step 1: `.swiftlint.yml` の custom_rules.mark_format.regex を編集**
+
+`app/.swiftlint.yml` の該当ブロック (現行):
+
+```yaml
+  # MARK comments should follow specific format
+  mark_format:
+    name: "MARK Format"
+    regex: "// MARK: - [A-Z]"
+    match_kinds:
+      - comment
+    message: "MARK comments should follow '// MARK: - Title' format"
+    severity: warning
+```
+
+を次に置換:
+
+```yaml
+  # MARK comments should follow Title Case (// MARK: - TitleCase ...)
+  # Fires only when a lowercase Latin letter follows "// MARK: - ".
+  # Japanese MARKs (e.g. "// MARK: - 永続化") are allowed (no match).
+  mark_format:
+    name: "MARK Format"
+    regex: "// MARK: - [a-z]"
+    match_kinds:
+      - comment
+    message: "MARK comments should follow '// MARK: - Title' format (Title Case required)"
+    severity: warning
+```
+
+- [ ] **Step 2: regex 動作確認**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep "mark_format" | wc -l
+```
+
+Expected: `0` (Title Case / 日本語 MARK のみなら全件消える)。
+
+ファイル単独で再確認したい場合:
+```bash
+cd app && swiftlint lint --quiet --path LeafTimerTests/TimerCoreLogicSpec.swift 2>&1 | grep mark_format
+```
+
+Expected: 何も出力されない。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/.swiftlint.yml
+git commit -m "$(cat <<'EOF'
+Issue #17: mark_format custom rule の regex を反転 (Title Case 要求の正方向ルールへ)
+
+`// MARK: - [A-Z]` は Title Case にマッチした時点で violation として
+fire してしまうバグ。意図は Title Case 要求なので `// MARK: - [a-z]`
+に反転 (lowercase が来たら違反)。日本語 MARK は [a-z] にマッチせず
+従来通り通る。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: 不要になった `swiftlint:disable:next mark_format` workaround を削除
+
+**Files:**
+- Modify: `app/LeafTimerTests/DataPersistenceTests.swift:38`
+- Modify: `app/LeafTimerTests/DataPersistenceTests.swift:354`
+- Modify: `app/LeafTimerTests/DataPersistenceTests.swift:421`
+- Modify: `app/LeafTimerTests/AudioSystemVerificationTests.swift:70`
+
+**背景:** Issue #15 で `swiftlint:disable:next mark_format` を 4 ヶ所追加した。Task 2 で regex を正方向に直したので、これらは不要 (Title Case と日本語 MARK は今後ヒットしない)。削除して workaround を清算する。
+
+- [ ] **Step 1: `DataPersistenceTests.swift` の 3 ヶ所を確認**
+
+Run:
+```bash
+cd app && grep -n "swiftlint:disable:next mark_format" LeafTimerTests/DataPersistenceTests.swift
+```
+
+Expected:
+```
+38:    // swiftlint:disable:next mark_format
+354:    // swiftlint:disable:next mark_format
+421:    // swiftlint:disable:next mark_format
+```
+
+- [ ] **Step 2: `DataPersistenceTests.swift` から 3 行を削除**
+
+Edit `app/LeafTimerTests/DataPersistenceTests.swift`:
+
+Line 38 周辺 (例) を:
+```swift
+    // swiftlint:disable:next mark_format
+    // MARK: - Setup
+```
+
+から
+```swift
+    // MARK: - Setup
+```
+
+に変える。354 / 421 も同様。各箇所の前後 2 行を読んで MARK タイトルが Title Case (英語) または日本語であることを確認してから削除する (lowercase だと違反になるため)。
+
+実装ヒント — `Edit` ツールで `// swiftlint:disable:next mark_format\n` を消す (前後の MARK 行は残す)。
+
+- [ ] **Step 3: `AudioSystemVerificationTests.swift:70` から 1 行を削除**
+
+Run (確認):
+```bash
+cd app && sed -n '68,72p' LeafTimerTests/AudioSystemVerificationTests.swift
+```
+
+該当行 `// swiftlint:disable:next mark_format` を削除。
+
+- [ ] **Step 4: 全 4 ヶ所が削除されたことを確認**
+
+Run:
+```bash
+cd app && grep -rn "swiftlint:disable:next mark_format" LeafTimerTests/ 2>&1
+```
+
+Expected: 何も出力されない。
+
+- [ ] **Step 5: swiftlint で mark_format 警告が引き続き 0 であることを確認**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep "mark_format" | wc -l
+```
+
+Expected: `0`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/LeafTimerTests/DataPersistenceTests.swift app/LeafTimerTests/AudioSystemVerificationTests.swift
+git commit -m "$(cat <<'EOF'
+Issue #17: Issue #15 で追加した mark_format workaround 4 ヶ所を削除
+
+Task 2 で custom rule の regex を正方向に修正したため、Title Case
+および日本語 MARK タイトルは今後 warning を出さない。
+`swiftlint:disable:next mark_format` は不要になったので削除し、
+workaround を清算する。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `blanket_disable_command` 警告を `disable:next` 化で解消
+
+**Files:**
+- Modify: `app/LeafTimerTests/ModernTimerViewSpec.swift:9`
+- Modify: `app/LeafTimerTests/ModernSettingViewSpec.swift:9`
+- Modify: `app/LeafTimerTests/TimerCoreLogicSpec.swift:12`
+
+**背景:** Quick の `spec()` は性質上長くなるため `function_body_length` を抑制したい。
+blanket disable (`// swiftlint:disable function_body_length` をファイル冒頭に置く) は
+`blanket_disable_command` ルールを trigger するため、`// swiftlint:disable:next function_body_length`
+を `override class func spec()` 直前に置くパターンに揃える。
+既に ReviewIntegrationSpec.swift:7 がこのパターンで実装済み (お手本)。
+
+- [ ] **Step 1: お手本パターンを確認**
+
+Run:
+```bash
+cd app && sed -n '5,10p' LeafTimerTests/ReviewIntegrationSpec.swift
+```
+
+Expected (お手本):
+```swift
+class ReviewIntegrationSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override class func spec() {
+```
+
+- [ ] **Step 2: `ModernTimerViewSpec.swift` を修正**
+
+現状 (L9 周辺):
+```swift
+class ModernTimerViewSpec: QuickSpec {
+    // swiftlint:disable function_body_length
+    override class func spec() {
+```
+
+→ に修正:
+```swift
+class ModernTimerViewSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override class func spec() {
+```
+
+(`disable` → `disable:next` の 1 単語追加)
+
+- [ ] **Step 3: `ModernSettingViewSpec.swift` を同様に修正**
+
+L9 の `// swiftlint:disable function_body_length` → `// swiftlint:disable:next function_body_length`
+
+- [ ] **Step 4: `TimerCoreLogicSpec.swift` を修正**
+
+現状 (L12 周辺):
+```swift
+// swiftlint:disable function_body_length
+class TimerCoreLogicSpec: QuickSpec {
+    override class func spec() {
+```
+
+→ に修正 (位置も class 内 spec 直前へ移動):
+```swift
+class TimerCoreLogicSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override class func spec() {
+```
+
+(L12 の blanket disable 行を削除し、`override class func spec()` 直前にインデント付きで挿入)
+
+- [ ] **Step 5: blanket_disable_command 警告が 0 であることを確認**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep blanket_disable_command | wc -l
+```
+
+Expected: `0`
+
+- [ ] **Step 6: function_body_length 警告が増えていないことを確認**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep function_body_length | wc -l
+```
+
+Expected: `0` (`disable:next` で spec() 全体が引き続き対象外)。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/LeafTimerTests/ModernTimerViewSpec.swift app/LeafTimerTests/ModernSettingViewSpec.swift app/LeafTimerTests/TimerCoreLogicSpec.swift
+git commit -m "$(cat <<'EOF'
+Issue #17: Quick spec の blanket disable を disable:next に変換
+
+ModernTimerViewSpec / ModernSettingViewSpec / TimerCoreLogicSpec の
+`swiftlint:disable function_body_length` (blanket) を、
+ReviewIntegrationSpec 流の `disable:next` パターン
+(`override class func spec()` 直前 1 行) に揃え、
+`blanket_disable_command` rule の trigger を解消。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `nimble_operator` ルールを無効化 (matcher 形を許容)
+
+**Files:**
+- Modify: `app/.swiftlint.yml:59` (opt_in から削除)
+- Modify: `app/.swiftlint.yml:127-132` (disabled_rules に追加)
+
+**背景:** Nimble は `expect(x).to(beNil())` / `expect(x).to(equal(3))` / `expect(x).to(beGreaterThan(0))` という matcher 形が BDD 流で可読性が高い。`nimble_operator` rule は全部 `==` / `>` 等の演算子形に強制してくるため、可読性を損ねる方向の rule。プロジェクト方針として matcher 形を採用するなら無効化が筋。Issue #17 では特に beNil() の false positive が問題提起されているが、実態は equal() / beGreaterThan() 含め広範囲に発火しているため、ルール自体を無効化する。
+
+- [ ] **Step 1: `.swiftlint.yml` から `nimble_operator` を opt_in_rules から削除**
+
+`app/.swiftlint.yml:59` の `  - nimble_operator` 行 (Style ブロック内) を削除。
+
+- [ ] **Step 2: `.swiftlint.yml` の disabled_rules に追加**
+
+現状 (L127-132):
+```yaml
+# Disabled rules (can be enabled gradually)
+disabled_rules:
+  - line_length  # Will be handled by SwiftFormat
+  - force_cast
+  - force_try
+  - todo
+  - comment_spacing  # Allow Japanese comments
+```
+
+→ に修正 (末尾に 1 行追加):
+```yaml
+# Disabled rules (can be enabled gradually)
+disabled_rules:
+  - line_length  # Will be handled by SwiftFormat
+  - force_cast
+  - force_try
+  - todo
+  - comment_spacing  # Allow Japanese comments
+  - nimble_operator  # Prefer BDD-style matchers (beNil/equal/beGreaterThan) over operators
+```
+
+- [ ] **Step 3: nimble_operator 警告が 0 であることを確認**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep nimble_operator | wc -l
+```
+
+Expected: `0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/.swiftlint.yml
+git commit -m "$(cat <<'EOF'
+Issue #17: nimble_operator ルールを無効化 (matcher 形を採用)
+
+Nimble は `expect(x).to(beNil())` / `expect(x).to(equal(3))` /
+`expect(x).to(beGreaterThan(0))` という matcher 形が BDD 流で可読性が
+高いため、プロジェクト方針として matcher 形を採用する。
+nimble_operator rule は演算子形に強制してくるため無効化。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: 最終確認 (全 test + 警告数の差分計測)
+
+**Files:**
+- 編集なし (検証のみ)
+
+- [ ] **Step 1: `make tests` で test 全 pass を確認**
+
+Run:
+```bash
+cd app && set -o pipefail && make tests 2>&1 | tail -15
+```
+
+Expected: `** TEST SUCCEEDED **` で終了。失敗があれば調査して修正後にこの Task を再実行。
+
+注意: `set -o pipefail` を必ず付ける (project CLAUDE.md ルール)。
+
+- [ ] **Step 2: 警告総数を計測**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep -cE "warning|error"
+```
+
+Expected: baseline 152 から大幅減。mark_format / blanket_disable_command / nimble_operator の合計分が消えている想定。
+
+- [ ] **Step 3: ルール別内訳を再計測 (PR 用)**
+
+Run:
+```bash
+cd app && swiftlint lint --quiet 2>&1 | grep -oE "\(([a-z_]+)\)$" | sort | uniq -c | sort -rn
+```
+
+Expected: `mark_format`, `blanket_disable_command`, `nimble_operator` の各カウントが 0。Task 1 で記録した baseline 内訳と比較して差分を PR 説明に記載。
+
+- [ ] **Step 4: push と PR 作成**
+
+Run:
+```bash
+git push -u origin feature/issue-17-swiftlint-cleanup
+```
+
+```bash
+gh pr create --title "Issue #17: SwiftLint 設定整備 (mark_format / blanket_disable / nimble_operator)" --body "$(cat <<'EOF'
+## Summary
+- `mark_format` custom rule の正規表現を反転 (Title Case 要求の正方向ルールへ)
+- Quick spec 3 ファイルの `blanket disable function_body_length` を `disable:next` に変換
+- `nimble_operator` rule を無効化し BDD 流 matcher 形 (`beNil` / `equal` / `beGreaterThan`) を採用
+- Issue #15 で追加した `swiftlint:disable:next mark_format` workaround 4 ヶ所を削除
+
+## Warning 数の変化
+- Before: 152
+- After: <Task 6 Step 2 の数値>
+- 解消ルール: mark_format / blanket_disable_command / nimble_operator (各 0 件)
+
+## Test Plan
+- [x] `make tests` 全 pass (108 tests, 26 skipped, 0 failures)
+- [x] `swiftlint lint` で対象 3 ルールの violation が 0 件
+- [x] 日本語 MARK タイトル (`// MARK: - 永続化` 等) が引き続き warning を出さないことを確認
+
+Closes #17
+EOF
+)"
+```
+
+- [ ] **Step 5: PR URL を報告**
+
+Output: PR URL を表示してタスク完了を宣言。
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Issue #17 ✅
+  - (1) mark_format regex バグ → Task 2 ✅
+  - (2) blanket_disable_command と Quick spec → Task 4 ✅
+  - (3) nimble_operator beNil() false positive → Task 5 ✅
+  - (関連) Issue #15 で追加した workaround の本格対応で吸収 → Task 3 ✅
+
+**2. Placeholder scan:** 全ステップにコード/コマンド本体を記載済み。TBD/TODO/「適切に」等の記述なし ✅
+
+**3. Type consistency:** YAML キー / コミットメッセージ / Issue # 参照が全タスクで揃っている ✅
+
+**4. 順序依存性:**
+- Task 2 → Task 3 (workaround 削除は regex 反転後でないと違反復活)
+- Task 4 と Task 5 は Task 2/3 と独立 (どちらが先でも可)
+- Task 6 (最終確認) は他全タスクの後


### PR DESCRIPTION
## Summary
- `mark_format` custom rule の正規表現を反転 (`[A-Z]` → `[a-z]`) し、Title Case 要求の正方向ルールへ修正
- Quick spec 3 ファイル (ModernTimerViewSpec / ModernSettingViewSpec / TimerCoreLogicSpec) の `blanket disable function_body_length` を `disable:next` に変換 (ReviewIntegrationSpec パターンに合流)
- `nimble_operator` rule を無効化し BDD 流 matcher 形 (`beNil` / `equal` / `beGreaterThan`) を採用
- Issue #15 で追加した `swiftlint:disable:next mark_format` workaround 4 ヶ所を削除 (本格対応で吸収)
- regex 反転で発見された既存違反 2 件併せて修正: `TimerViewModel.swift` の `MARK: - methods` → `Methods`、`AudioSystemVerificationTests.swift` の `MARK: - iOS 17 ...` は Apple 製品名のため例外として `disable:next` で明示

## Warning 数の変化
| | Before | After | Δ |
|---|---|---|---|
| **Total** | **152** | **66** | **-86** |
| mark_format | 76 | 0 | -76 |
| nimble_operator | 7 | 0 | -7 |
| blanket_disable_command | 3 | 0 | -3 |

残った 66 warnings (attributes:22, trailing_newline:18, implicit_return:6 など) は本 Issue の対象外で、別 Issue または時間がある時に整理する。

## Test Plan
- [x] `make tests` 全 pass (108 tests, 26 skipped (#16 既知), 0 failures)
- [x] `swiftlint lint` で対象 3 ルールの violation が 0 件
- [x] 日本語 MARK タイトル (`// MARK: - 永続化テスト` 等) が引き続き warning を出さないことを確認
- [x] Apple 製品名 (`// MARK: - iOS 17 最適化機能テスト`) は意図的に `disable:next mark_format` で例外化

Closes #17