### PR TITLE
docs: セッション振り返り 3 件を CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,11 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 ### 失敗からの教訓
 
 - Edit/Write が失敗した時や、想定外のファイル変更を検出した時は、まず並行ターミナルの別 Claude Code セッション（または別プロセス）による書き換えを疑い、ファイルの timestamp と内容を確認してから操作を続ける。気づかず上書きすると他セッションの in-progress work を破壊するため、「Edit 失敗 = 何かが書き換えた」と即座に状況確認する習慣にする。
+- SwiftLint の `custom_rules` の regex は「違反パターン」を書くのが正方向。新規 custom rule を入れる前に、**意図する正例と反例の両方をテキストで列挙して regex を当て**、ヒット方向が反転していないかを必ず確認する。Issue #15 では反転バグに気付かず `disable:next` workaround を 4 ヶ所撒く事故が起きた。
 
 ### 効率化ルール
 
 - 新規 hook スクリプト（SessionEnd/SessionStart など）を settings.json に配線する前に、sample JSON を stdin に pipe-test して bail 条件・self-detach・sentinel ガードを単体検証する。配線後の silent failure（特に `claude -p --bare` の OAuth 切れのような沈黙失敗）を未然に検出できる。
+- plan-driven な PR では、Issue #15 の `f2df20e` の convention に倣い、**実装の最初のコミットとして** `docs/superpowers/plans/<date>-<feature>.md` を含める。PR 作成後の追い commit になると CI 履歴とレビュー導線がズレるため、ブランチ作成直後に plan を commit する。
+- ブランチ push や `gh pr create` の前に、必ず `git fetch && gh pr list --state all --head <branch>` で既存 PR / merge 状況を確認する。ローカル master が古いまま push して「既に MERGED」で空振りするのを防ぐ。
 


### PR DESCRIPTION
## Summary

前回セッション (Issue #17 SwiftLint 整備 / PR #19) で得た学びを CLAUDE.md の「振り返りからの学び」セクションに 3 件追記。

### 追記内容

#### 効率化ルール
- **plan-driven な PR では最初の commit に plan ドキュメントを含める**
  Issue #15 の `f2df20e` の convention に倣う。PR 作成後の追い commit になると CI 履歴とレビュー導線がズレる
- **ブランチ push / `gh pr create` の前に既存 PR / merge 状況を確認**
  `git fetch && gh pr list --state all --head <branch>` を打つ。ローカル master が古いまま push して「既に MERGED」で空振りするのを防ぐ

#### 失敗からの教訓
- **SwiftLint `custom_rules` の regex は「違反パターン」を書くのが正方向**
  Issue #15 では反転バグに気付かず `disable:next` workaround を 4 ヶ所撒く事故が発生。新規 custom rule を入れる前に正例/反例の両方をテキストで列挙して regex を当て、ヒット方向を必ず確認する

## Test plan

- [x] CLAUDE.md の差分が 3 件のみであることを確認
- [x] 既存セクション (失敗からの教訓 / 効率化ルール) の構造を維持
- [ ] レビューで内容承認

🤖 Generated with [Claude Code](https://claude.com/claude-code)