### PR TITLE
Issue #12: Bash pipefail ガイドラインを CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 
 - Edit/Write が失敗した時や、想定外のファイル変更を検出した時は、まず並行ターミナルの別 Claude Code セッション（または別プロセス）による書き換えを疑い、ファイルの timestamp と内容を確認してから操作を続ける。気づかず上書きすると他セッションの in-progress work を破壊するため、「Edit 失敗 = 何かが書き換えた」と即座に状況確認する習慣にする。
 - SwiftLint の `custom_rules` の regex は「違反パターン」を書くのが正方向。新規 custom rule を入れる前に、**意図する正例と反例の両方をテキストで列挙して regex を当て**、ヒット方向が反転していないかを必ず確認する。Issue #15 では反転バグに気付かず `disable:next` workaround を 4 ヶ所撒く事故が起きた。
+- Bash でビルド/テスト系コマンド (`make` / `xcodebuild` / `npm test` / `pytest` 等) を `| tail` / `| head` / `| grep` でフィルタする時は、必ず `set -o pipefail` をコマンド前に置くか、`${PIPESTATUS[0]}` で元コマンドの exit code を取得する (または `tee` で全出力をファイルに残してから `grep` する)。Issue #9 で `make tests 2>&1 | tail -80` の exit code が tail の 0 に隠れて、`make: *** [unit-tests] Error 70` という失敗を「成功」と誤判定する事故が発生した。
 
 ### 効率化ルール
 


### PR DESCRIPTION
## Summary

Issue #12 で提案された **A 案 (ガイドライン追記)** を実施。LeafTimer/CLAUDE.md の「振り返りからの学び」→「失敗からの教訓」セクションに 1 件追加。

## 背景

Issue #9 (PR #14 関連) 対応中、`make tests 2>&1 | tail -80` で `make` の exit code が `tail` の正常終了 (0) に隠れて、`make: *** [unit-tests] Error 70` という失敗を「成功」と誤判定する事故が発生。再発防止のため、Bash パイプ越しのビルド/テスト判定時に exit code を担保するルールを明文化。

## 採用案と見送り案

- ✅ **A 案 (本 PR)**: CLAUDE.md にガイドライン追記。即時実施可、軽量
- 🕒 **B 案**: PreToolUse hook で警告。中期検討 (実装コストがそこそこ)
- ❌ **C 案**: 専用スキル `pipe-safe-exec` 化。オーバーキルと判断

## 推奨される対処法 (3 通り)

1. `set -o pipefail` をコマンド前に置く
2. `\${PIPESTATUS[0]}` で元コマンドの exit code を取得
3. `tee` で全出力をファイルに残してから `grep`

## 注意

PR #20 (CLAUDE.md 振り返り反映) と同じファイルを編集するため、PR #20 が先にマージされた場合は rebase が必要。

Closes #12

## Test plan

- [x] CLAUDE.md の差分が 1 行追加のみ
- [x] 「失敗からの教訓」セクションのスタイル (箇条書き 1 行) を踏襲
- [ ] レビューで承認

🤖 Generated with [Claude Code](https://claude.com/claude-code)