### PR TITLE
docs: session-retrospective 2 件を「効率化ルール」に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,4 +82,6 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 - 新規 hook スクリプト（SessionEnd/SessionStart など）を settings.json に配線する前に、sample JSON を stdin に pipe-test して bail 条件・self-detach・sentinel ガードを単体検証する。配線後の silent failure（特に `claude -p --bare` の OAuth 切れのような沈黙失敗）を未然に検出できる。
 - plan-driven な PR では、Issue #15 の `f2df20e` の convention に倣い、**実装の最初のコミットとして** `docs/superpowers/plans/<date>-<feature>.md` を含める。PR 作成後の追い commit になると CI 履歴とレビュー導線がズレるため、ブランチ作成直後に plan を commit する。
 - ブランチ push や `gh pr create` の前に、必ず `git fetch && gh pr list --state all --head <branch>` で既存 PR / merge 状況を確認する。ローカル master が古いまま push して「既に MERGED」で空振りするのを防ぐ。
+- `superpowers:subagent-driven-development` を採用する時、Plan の Task が「観察+編集+検証+commit」のような小粒で密接結合なら、Task ごとに subagent を dispatch せず**複数 Task を 1 subagent に full text で束ねて渡す**。レビューはまとめて 2 段階 (spec compliance → code quality) で実施する。Why: 個別 dispatch のオーバーヘッド (context 渡し / Tool 再 load / agent boot) > 実行コストになることがある。Issue #16 で Plan の Task 2-6 を 1 subagent に束ね、起動コストを抑えつつ品質ゲートは両 reviewer で確保できた。
+- Agent tool 経由で subagent に `cd app && make unit-tests` を実行させる時、Bash の `timeout` を明示的に `600000` (10 分) に設定するよう subagent 指示書に書く。Why: xcodebuild + simulator boot + test 実行で 2〜5 分かかるため、Bash のデフォルト 2 分でタイムアウトすると、せっかくのテスト実行が無駄になる。
 


### PR DESCRIPTION
## Summary

2026-05-23 のセッション (PR #20 docs-reflection / PR #21 Issue #12 / PR #22 Issue #16) の振り返りから得た学び 2 件を CLAUDE.md「効率化ルール」に追記。

## 追記内容

### 1. superpowers:subagent-driven-development の Task 束ね運用

> Plan の Task が「観察+編集+検証+commit」のような小粒で密接結合なら、Task ごとに subagent を dispatch せず**複数 Task を 1 subagent に full text で束ねて渡す**。

**Why**: 個別 dispatch のオーバーヘッド (context 渡し / Tool 再 load / agent boot) > 実行コストになることがある。Issue #16 (PR #22) で Plan の Task 2-6 を 1 subagent に束ね、起動コストを抑えつつ品質ゲートは spec/code 両 reviewer で確保できた実例で validate された。

### 2. Agent tool 経由で make unit-tests を呼ぶ時の timeout 明示

> Agent tool 経由で subagent に `cd app && make unit-tests` を実行させる時、Bash の `timeout` を明示的に `600000` (10 分) に設定するよう subagent 指示書に書く。

**Why**: xcodebuild + simulator boot + test 実行で 2〜5 分かかるため、Bash のデフォルト 2 分でタイムアウトすると、せっかくのテスト実行が無駄になる。Issue #16 の subagent 指示書で明示的に書いたら subagent が timeout なく完走した。

## 経緯

`/daily-issue-triage` → `superpowers:writing-plans` → `superpowers:subagent-driven-development` → `session-retrospective` の skill chain で実施。3 PR (#20/#21/#22) のうち PR #20 と PR #22 はユーザー手動 merge 済み、PR #21 のみ open (rebase で コンフリクト解消済み)。

## Test plan

- [x] CLAUDE.md の差分が 2 行追加のみ
- [x] 「効率化ルール」セクションの既存スタイル (`- 一文要約。Why: ...`) を踏襲
- [ ] レビューで内容承認

🤖 Generated with [Claude Code](https://claude.com/claude-code)