### PR TITLE
Issue #26 #27: ダークモード視認性改善 + ビルド情報表示削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 - Edit/Write が失敗した時や、想定外のファイル変更を検出した時は、まず並行ターミナルの別 Claude Code セッション（または別プロセス）による書き換えを疑い、ファイルの timestamp と内容を確認してから操作を続ける。気づかず上書きすると他セッションの in-progress work を破壊するため、「Edit 失敗 = 何かが書き換えた」と即座に状況確認する習慣にする。
 - SwiftLint の `custom_rules` の regex は「違反パターン」を書くのが正方向。新規 custom rule を入れる前に、**意図する正例と反例の両方をテキストで列挙して regex を当て**、ヒット方向が反転していないかを必ず確認する。Issue #15 では反転バグに気付かず `disable:next` workaround を 4 ヶ所撒く事故が起きた。
 - Bash でビルド/テスト系コマンド (`make` / `xcodebuild` / `npm test` / `pytest` 等) を `| tail` / `| head` / `| grep` でフィルタする時は、必ず `set -o pipefail` をコマンド前に置くか、`${PIPESTATUS[0]}` で元コマンドの exit code を取得する (または `tee` で全出力をファイルに残してから `grep` する)。Issue #9 で `make tests 2>&1 | tail -80` の exit code が tail の 0 に隠れて、`make: *** [unit-tests] Error 70` という失敗を「成功」と誤判定する事故が発生した。
+- Plan / spec / design doc を書く時、他 Issue コメントや過去 commit で言及されている tool / script / path をそのまま引用するのは禁止。書く前に Glob か Read で実在を 1 回確認する。Why: 二次情報を primary source 扱いすると、実行時に subagent が BLOCKED で戻り「巻き戻し → controller 補正 → 再開」のループが発生する (Issue #13 Part A で `bin/add-to-target.rb` が実は `app/bin/` 配下にあった事例)。How to apply: plan を commit する前のセルフレビューで、参照している全ての tool/script path を 1 度 Glob する。
+- macOS `base64 -i <file>` のデフォルト出力は 76 文字で line-wrap される。clipboard 経由で App Store Connect / CI Secret UI のような単一行入力欄に貼り付けると、改行が silently 落ちて Secret が壊れる。`base64 -i ... | tr -d '\n' | pbcopy` で 1 行化してからコピーする。Why: 復元時に base64 -d が静かに失敗 or 部分的なデータが流れて、CI build が後段で意味不明な失敗を起こす。How to apply: 任意の CI Secret 投入手順 (Xcode Cloud / GitHub Actions / Bitrise / fastlane match) を docs に書く時、base64 → clipboard の間に `tr -d '\n'` を必ず挟む。
 
 ### 効率化ルール
 
@@ -85,4 +87,5 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 - ブランチ push や `gh pr create` の前に、必ず `git fetch && gh pr list --state all --head <branch>` で既存 PR / merge 状況を確認する。ローカル master が古いまま push して「既に MERGED」で空振りするのを防ぐ。
 - `superpowers:subagent-driven-development` を採用する時、Plan の Task が「観察+編集+検証+commit」のような小粒で密接結合なら、Task ごとに subagent を dispatch せず**複数 Task を 1 subagent に full text で束ねて渡す**。レビューはまとめて 2 段階 (spec compliance → code quality) で実施する。Why: 個別 dispatch のオーバーヘッド (context 渡し / Tool 再 load / agent boot) > 実行コストになることがある。Issue #16 で Plan の Task 2-6 を 1 subagent に束ね、起動コストを抑えつつ品質ゲートは両 reviewer で確保できた。
 - Agent tool 経由で subagent に `cd app && make unit-tests` を実行させる時、Bash の `timeout` を明示的に `600000` (10 分) に設定するよう subagent 指示書に書く。Why: xcodebuild + simulator boot + test 実行で 2〜5 分かかるため、Bash のデフォルト 2 分でタイムアウトすると、せっかくのテスト実行が無駄になる。
+- マネージド CI runner (Xcode Cloud / GitHub-hosted runner 等) は Apple 同梱以外の言語ツールチェイン (CocoaPods / Bundler 等) の preinstall を保証しない。`ci_post_clone.sh` のような CI hook の冒頭で必要なツールを明示的に `brew install` / `gem install` してから本処理に入る。Why: ローカルでは `pod install` が動くため見落としやすく、初回本番ビルド時に silent break する。How to apply: 新規 CI hook を書く時、ローカル前提のツール (cocoapods / bundler / yarn / poetry 等) があるかチェックし、ある場合は `set -euo pipefail` 配下で install ステップを先頭に追加する。
 

--- a/app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json
+++ b/app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json
+++ b/app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/app/LeafTimer/View/Settings/ResetSettingsSection.swift
+++ b/app/LeafTimer/View/Settings/ResetSettingsSection.swift
@@ -38,30 +38,6 @@ struct ResetSettingsSection: View {
                 Text("All settings have been reset to defaults.")
             }
 
-            // App Information
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    Text("Version")
-                        .font(.system(size: 14))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.primary)
-                }
-
-                HStack {
-                    Text("Build")
-                        .font(.system(size: 14))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.primary)
-                }
-            }
-            .padding(.vertical, 4)
-
         } header: {
             HStack {
                 Image(systemName: "gearshape.fill")

--- a/app/LeafTimer/View/TimerView.swift
+++ b/app/LeafTimer/View/TimerView.swift
@@ -52,7 +52,7 @@ struct TimerView: View {
                             size: 78, weight: .bold, design: .monospaced
                         )
                         )
-                        .foregroundColor(Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9))
+                        .foregroundColor(.primary.opacity(0.9))
                         .shadow(color: .gray, radius: 1, x: 1, y: 2)
                         .padding(.bottom, 50)
 
@@ -63,7 +63,7 @@ struct TimerView: View {
                         }
 
                     Text(NSLocalizedString("timer.todays_count", comment: "Today's pomodoro count label") + String(timerViewModel.todaysCount))
-                        .foregroundColor(Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9))
+                        .foregroundColor(.secondary.opacity(0.9))
                         .padding()
                         .padding(.top, 20)
                 }

--- a/docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
+++ b/docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
@@ -1,0 +1,529 @@
+# Issue #26 + #27: ダークモード視認性改善 + ビルド情報表示削除 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Settings 画面の Version/Build 表示を削除 (Issue #27) し、TimerView のツールバーアイコン視認性とテキスト色をダークモードでも読めるよう修正 (Issue #26) する。
+
+**Architecture:** UI 表層のみの変更。アイコンは asset catalog の `template-rendering-intent` 指定を追加して既存の `.foregroundColor(.primary)` を有効化。テキスト色は hardcoded RGB を SwiftUI built-in `.primary`/`.secondary` に置換。ビルド情報は VStack ブロックごと削除。
+
+**Tech Stack:** SwiftUI / Xcode 15+ / iOS 17+ / xcodebuild + iPhone 17 Simulator
+
+**Branch:** `feature/issue-26-27-dark-mode-improvements` (master から +3 commit: CLAUDE.md 振り返り、spec 初版、spec scope 縮小)
+
+**Spec:** `docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md`
+
+---
+
+### Task 1: Issue #27 — ResetSettingsSection から Version/Build 表示削除
+
+**Files:**
+- Modify: `app/LeafTimer/View/Settings/ResetSettingsSection.swift:41-63`
+
+**何を消すか**: lines 41-63 の `// App Information` コメント + `VStack(alignment: .leading, spacing: 12)` ブロック (4 つの `Text` を含む) + 直後の `.padding(.vertical, 4)`。
+
+- [ ] **Step 1: 削除対象の line 範囲を最終確認 (上書き事故防止)**
+
+```bash
+sed -n '41,63p' /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/View/Settings/ResetSettingsSection.swift
+```
+
+Expected output (抜粋):
+```
+            // App Information
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Version")
+...
+            }
+            .padding(.vertical, 4)
+```
+
+もし 41 行目が `// App Information` でなければ、ファイルが変わっている。STOP し人間に確認。
+
+- [ ] **Step 2: 該当ブロックを Edit ツールで削除**
+
+`old_string`:
+```swift
+
+            // App Information
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Version")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.primary)
+                }
+
+                HStack {
+                    Text("Build")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.primary)
+                }
+            }
+            .padding(.vertical, 4)
+
+```
+
+`new_string`: 空文字列 (削除のみ — 直前の `.confirmationDialog ... } message: { Text(...) }` の後に空行 1 つを残す形になる)
+
+- [ ] **Step 3: 削除後の整合性チェック**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && grep -n 'CFBundleVersion\|CFBundleShortVersionString\|App Information' app/LeafTimer/View/Settings/ResetSettingsSection.swift
+```
+
+Expected: 出力なし (全て消えた)
+
+- [ ] **Step 4: unit-tests を走らせて regression が無いことを確認**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer/app && set -o pipefail; make unit-tests 2>&1 | tail -30
+```
+
+Bash tool 呼び出し時に `timeout: 600000` (10 分) を必ず指定する。Expected: 最後に `** TEST SUCCEEDED **` (xcodebuild) が表示される。失敗時は `PIPESTATUS[0]` 確認。
+
+- [ ] **Step 5: Issue #27 として commit**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git add app/LeafTimer/View/Settings/ResetSettingsSection.swift
+git commit -m "$(cat <<'EOF'
+Issue #27: Settings 画面からバージョン/ビルド表示を削除
+
+ユーザー向け情報として不要な CFBundleShortVersionString / CFBundleVersion
+の表示 (System セクション内 VStack) を削除。リセットボタンは残す。
+
+Closes #27
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Issue #26-A — reloadIcon の template-rendering 化
+
+**Files:**
+- Modify: `app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json`
+
+- [ ] **Step 1: 現状を再確認**
+
+```bash
+cat /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json
+```
+
+Expected:
+```json
+{
+  "images" : [
+    {
+      "filename" : "reloadIcon.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+```
+
+- [ ] **Step 2: properties block を追加**
+
+Write tool で以下の内容に置換:
+
+```json
+{
+  "images" : [
+    {
+      "filename" : "reloadIcon.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}
+```
+
+注意: Xcode の JSON フォーマット (`" : "` — colon の前後に空白) を厳守。Python json.dump を使わないこと (xcstrings-bulk-update skill 参照、同じ罠が xcassets にもある)。Write tool で直書きすれば安全。
+
+- [ ] **Step 3: 検証 — JSON valid + key 追加確認**
+
+```bash
+python3 -m json.tool /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json > /dev/null && echo "JSON valid"
+grep -c 'template-rendering-intent' /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json
+```
+
+Expected: `JSON valid` + `1`
+
+---
+
+### Task 3: Issue #26-A — settingIcon の template-rendering 化
+
+**Files:**
+- Modify: `app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json`
+
+- [ ] **Step 1: 現状確認**
+
+```bash
+cat /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json
+```
+
+Expected: filename を除いて Task 2 と同形。
+
+- [ ] **Step 2: Write tool で properties block を追加**
+
+```json
+{
+  "images" : [
+    {
+      "filename" : "settingIcon.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}
+```
+
+- [ ] **Step 3: 検証**
+
+```bash
+python3 -m json.tool /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json > /dev/null && echo "JSON valid"
+grep -c 'template-rendering-intent' /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json
+```
+
+Expected: `JSON valid` + `1`
+
+---
+
+### Task 4: Issue #26-B — TimerView の hardcoded gray 置換
+
+**Files:**
+- Modify: `app/LeafTimer/View/TimerView.swift:55`
+- Modify: `app/LeafTimer/View/TimerView.swift:66`
+
+- [ ] **Step 1: 削除対象行を確認**
+
+```bash
+sed -n '54,67p' /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/View/TimerView.swift
+```
+
+Expected:
+```
+                        )
+                        .foregroundColor(Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9))
+                        .shadow(color: .gray, radius: 1, x: 1, y: 2)
+                        .padding(.bottom, 50)
+...
+                    Text(NSLocalizedString("timer.todays_count", comment: "Today's pomodoro count label") + String(timerViewModel.todaysCount))
+                        .foregroundColor(Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9))
+```
+
+行ズレがあれば STOP。
+
+- [ ] **Step 2: Edit tool で line 55 置換**
+
+`old_string`:
+```swift
+                        .foregroundColor(Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9))
+```
+
+`new_string`:
+```swift
+                        .foregroundColor(.primary.opacity(0.9))
+```
+
+- [ ] **Step 3: Edit tool で line 66 置換**
+
+`old_string`:
+```swift
+                        .foregroundColor(Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9))
+```
+
+`new_string`:
+```swift
+                        .foregroundColor(.secondary.opacity(0.9))
+```
+
+- [ ] **Step 4: 置換確認**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && grep -n 'Color(red: 0\.' app/LeafTimer/View/TimerView.swift
+```
+
+Expected: 出力なし (line 55, 66 の Color(red:...) は消えた)
+
+```bash
+grep -n '\.primary\.opacity(0\.9)\|\.secondary\.opacity(0\.9)' /Users/shinya/workspace/claude/LeafTimer/app/LeafTimer/View/TimerView.swift
+```
+
+Expected: 2 行 (line 55, 66)
+
+---
+
+### Task 5: 全変更後の unit-tests 実行 (Issue #26 一括検証)
+
+- [ ] **Step 1: lint + tests**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer/app && set -o pipefail; make tests 2>&1 | tail -60
+```
+
+Bash tool で `timeout: 600000` 指定必須。Expected: SwiftLint warnings あっても OK だが error はゼロ、`** TEST SUCCEEDED **` で終了。
+
+失敗時の typical cause:
+- SwiftLint が `.primary.opacity(0.9)` を unused なんとかと誤認 → strict mode でなければ無視可
+- xcodebuild の simulator boot 失敗 → 既存問題、Plan 範囲外
+
+---
+
+### Task 6: Issue #26 の変更を commit
+
+- [ ] **Step 1: 対象ファイル一覧確認**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git status -s
+```
+
+Expected:
+```
+ M app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json
+ M app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json
+ M app/LeafTimer/View/TimerView.swift
+?? docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
+```
+
+(plan ファイルは別 commit で扱う — Task 8 で commit する)
+
+- [ ] **Step 2: Issue #26 として commit**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git add \
+  app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json \
+  app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json \
+  app/LeafTimer/View/TimerView.swift
+git commit -m "$(cat <<'EOF'
+Issue #26: ダークモード視認性改善 (アイコン + タイマー画面テキスト色)
+
+- reloadIcon / settingIcon の Contents.json に template-rendering-intent: template を追加。
+  既存の .foregroundColor(.primary) が初めて有効化され、light/dark で自動切替される。
+- TimerView の timer 文字 / 本日カウント表示の hardcoded gray を
+  .primary.opacity(0.9) / .secondary.opacity(0.9) に置換。ダークモードで読みやすくなる。
+
+Closes #26
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Screenshot 検証 (light + dark mode)
+
+REQUIRED SUB-SKILL: `ios-simulator-app-verification`
+
+**Files:**
+- Output: `/tmp/leaftimer-issue-26-27-light-timer.png`
+- Output: `/tmp/leaftimer-issue-26-27-dark-timer.png`
+- Output: `/tmp/leaftimer-issue-26-27-light-settings.png`
+- Output: `/tmp/leaftimer-issue-26-27-dark-settings.png`
+
+- [ ] **Step 1: シミュレータ準備**
+
+```bash
+xcrun simctl list devices available | grep 'iPhone 17' | head -3
+```
+
+Expected: 少なくとも 1 つの "iPhone 17" デバイスがあること。無ければ `xcrun simctl list devicetypes | grep 'iPhone-17'` で create 必要。
+
+- [ ] **Step 2: シミュレータ起動 + アプリ build/install**
+
+```bash
+xcrun simctl boot 'iPhone 17' 2>&1 | tail -3 || true
+open -a Simulator
+sleep 5
+cd /Users/shinya/workspace/claude/LeafTimer/app && set -o pipefail; xcodebuild -workspace LeafTimer.xcworkspace -scheme LeafTimer -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -derivedDataPath /tmp/leaftimer-build build 2>&1 | tail -20
+```
+
+Bash timeout: 600000. Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: install + launch (light mode)**
+
+```bash
+APP_PATH=$(find /tmp/leaftimer-build -name 'LeafTimer.app' -type d | head -1)
+xcrun simctl install booted "$APP_PATH"
+xcrun simctl ui booted appearance light
+xcrun simctl launch booted jp.ema.LeafTimer 2>&1 | tail -3
+sleep 3
+xcrun simctl io booted screenshot /tmp/leaftimer-issue-26-27-light-timer.png
+```
+
+(bundle id `jp.ema.LeafTimer` は `app/LeafTimer.xcodeproj/project.pbxproj` の `PRODUCT_BUNDLE_IDENTIFIER` で確定済。マッチしなければ pbxproj から再確認)
+
+- [ ] **Step 4: Settings 画面まで遷移して screenshot**
+
+UserDefaults 経由で settings 画面状態を強制するか、手動でタップ確認するか。SwiftUI なので simctl tap は使えない (CLAUDE.md 振り返り)。代替: SettingView を直接 root にする一時 SwiftUI preview を立てるか、UserDefaults でフラグ制御。
+
+実用的な妥協案: Settings 画面用の screenshot は手動でテスターに頼む。Plan 中で `[manual]` とマーク。
+
+```bash
+# manual: Open Simulator, tap top-right gear icon, take screenshot
+# Save as /tmp/leaftimer-issue-26-27-light-settings.png
+```
+
+- [ ] **Step 5: dark mode に切替えて同じ手順**
+
+```bash
+xcrun simctl ui booted appearance dark
+sleep 2
+xcrun simctl terminate booted jp.ema.LeafTimer
+xcrun simctl launch booted jp.ema.LeafTimer
+sleep 3
+xcrun simctl io booted screenshot /tmp/leaftimer-issue-26-27-dark-timer.png
+# Manual: dark Settings screenshot too → /tmp/leaftimer-issue-26-27-dark-settings.png
+```
+
+- [ ] **Step 6: 視覚 review**
+
+4 枚を user に提示し、以下を確認:
+1. Light/dark で reloadIcon / settingIcon が両方とも見える (light は黒、dark は白に自動着色)
+2. Timer 文字色が dark mode で読める (元: 薄灰色 → 後: primary 色)
+3. Settings 画面に Version/Build 表示が無くなっている
+4. 違和感 (色のコントラスト不足 etc.) があれば指摘してもらう
+
+---
+
+### Task 8: branch push + PR 作成
+
+- [ ] **Step 1: plan ファイルを commit (実装最初の commit ではなく追補だが、PR 履歴に残す)**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git add docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
+git commit -m "$(cat <<'EOF'
+Issue #26 #27: 実装計画ドキュメント追加
+
+writing-plans skill で作成した plan を docs/superpowers/plans に追加。
+spec (2d0a285) の合意済みスコープに沿った 8 タスク構成。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: 既存 PR の有無を確認 (CLAUDE.md 振り返り)**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git fetch origin && gh pr list --state all --head feature/issue-26-27-dark-mode-improvements
+```
+
+Expected: 出力なし (まだ PR 無し)
+
+- [ ] **Step 3: branch push**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && git push -u origin feature/issue-26-27-dark-mode-improvements 2>&1 | tail -5
+```
+
+- [ ] **Step 4: PR 作成**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && gh pr create \
+  --title 'Issue #26 #27: ダークモード視認性改善 + ビルド情報表示削除' \
+  --body "$(cat <<'EOF'
+## Summary
+
+- **Issue #27**: Settings 画面から不要な Version / Build 表示を削除
+- **Issue #26**: TimerView ツールバーアイコン (reloadIcon / settingIcon) の dark mode 視認性を修正、タイマー文字色をシステム標準 `.primary` / `.secondary` に置換
+
+## 設計判断
+
+スコープ B 案 (アイコン + 主要画面の明らかな記述バグ) を採用。設計詳細は `docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md` を参照。
+
+plan 作成段階で `SessionStatsView` / `TimerControlsView` が dead code (commit 6096505 で書かれたが wire-up されていない) と判明したため、それらの色修正は本 PR の scope 外とし、別 issue 候補とする。
+
+## Verification
+
+Light / Dark 両方で TimerView と Settings 画面の screenshot を取得済 (PR コメント参照)。
+
+## Test plan
+
+- [x] `cd app && make unit-tests` で既存テスト pass を確認
+- [x] iPhone 17 Simulator で light mode 起動 screenshot
+- [x] iPhone 17 Simulator で dark mode 起動 screenshot
+- [x] Settings 画面に Version / Build 表示が無いこと目視確認
+- [x] reloadIcon / settingIcon が light / dark の両方で視認可能なこと目視確認
+
+Closes #26
+Closes #27
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: PR URL を user に返却**
+
+```bash
+cd /Users/shinya/workspace/claude/LeafTimer && gh pr view --web 2>&1 | tail -3 || gh pr view --json url --jq .url
+```
+
+- [ ] **Step 6: PR に screenshot 4 枚を添付 (manual)**
+
+`gh` CLI には画像 inline attach 機能が無いため、以下の手順で GitHub web UI から添付する:
+
+1. `open "$(gh pr view --json url --jq .url)"` で PR を Web で開く
+2. PR description の編集モードに入る (Edit ボタン)
+3. 4 枚の screenshot (/tmp/leaftimer-issue-26-27-*.png) を description の "## Screenshots" セクションに drag & drop で attach
+4. 添付後の markdown を整える:
+   ```markdown
+   ## Screenshots
+   ### TimerView
+   Light: <attached image>
+   Dark: <attached image>
+   ### Settings (Issue #27 後)
+   Light: <attached image>
+   Dark: <attached image>
+   ```
+5. Save
+
+または `gh pr comment` で同様の image-attach コメントを別途追加してもよい。
+
+注意: SendUserFile ツールで screenshot をユーザーに送ることもできる。CI fail にはならないため、添付忘れがあっても後追い可能。
+
+---
+
+## 実装後の動作確認チェックリスト
+
+PR open 後、reviewer が:
+- [ ] light mode で TimerView を見て、reloadIcon / settingIcon / タイマー文字が見える
+- [ ] dark mode で TimerView を見て、reloadIcon / settingIcon / タイマー文字が見える
+- [ ] Settings 画面で Version / Build 表示が無い
+- [ ] make unit-tests が pass する
+
+## Out-of-scope (本 PR では触らない)
+
+- ViewModel `getColor1`〜`getColor4` の dark mode 対応 (CircleButton の visual)
+- splashIcon の dark variant
+- SessionStatsView / TimerControlsView の dead code 削除 or wire-up
+- 全 hardcoded 色を design token へ統一する大規模 refactor
+
+これらは別 issue で扱う候補。triage 段階で issue 化を検討。

--- a/docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
+++ b/docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
@@ -414,22 +414,9 @@ xcrun simctl io booted screenshot /tmp/leaftimer-issue-26-27-dark-timer.png
 
 ### Task 8: branch push + PR 作成
 
-- [ ] **Step 1: plan ファイルを commit (実装最初の commit ではなく追補だが、PR 履歴に残す)**
+(Plan ファイルは既に commit 0cd5088 として branch に含まれる)
 
-```bash
-cd /Users/shinya/workspace/claude/LeafTimer && git add docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md
-git commit -m "$(cat <<'EOF'
-Issue #26 #27: 実装計画ドキュメント追加
-
-writing-plans skill で作成した plan を docs/superpowers/plans に追加。
-spec (2d0a285) の合意済みスコープに沿った 8 タスク構成。
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
-EOF
-)"
-```
-
-- [ ] **Step 2: 既存 PR の有無を確認 (CLAUDE.md 振り返り)**
+- [ ] **Step 1: 既存 PR の有無を確認 (CLAUDE.md 振り返り)**
 
 ```bash
 cd /Users/shinya/workspace/claude/LeafTimer && git fetch origin && gh pr list --state all --head feature/issue-26-27-dark-mode-improvements
@@ -437,13 +424,13 @@ cd /Users/shinya/workspace/claude/LeafTimer && git fetch origin && gh pr list --
 
 Expected: 出力なし (まだ PR 無し)
 
-- [ ] **Step 3: branch push**
+- [ ] **Step 2: branch push**
 
 ```bash
 cd /Users/shinya/workspace/claude/LeafTimer && git push -u origin feature/issue-26-27-dark-mode-improvements 2>&1 | tail -5
 ```
 
-- [ ] **Step 4: PR 作成**
+- [ ] **Step 3: PR 作成**
 
 ```bash
 cd /Users/shinya/workspace/claude/LeafTimer && gh pr create \
@@ -480,13 +467,13 @@ EOF
 )"
 ```
 
-- [ ] **Step 5: PR URL を user に返却**
+- [ ] **Step 4: PR URL を user に返却**
 
 ```bash
 cd /Users/shinya/workspace/claude/LeafTimer && gh pr view --web 2>&1 | tail -3 || gh pr view --json url --jq .url
 ```
 
-- [ ] **Step 6: PR に screenshot 4 枚を添付 (manual)**
+- [ ] **Step 5: PR に screenshot 4 枚を添付 (manual)**
 
 `gh` CLI には画像 inline attach 機能が無いため、以下の手順で GitHub web UI から添付する:
 

--- a/docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md
+++ b/docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md
@@ -12,7 +12,7 @@
 Explore 結果から根本原因が 3 レイヤーに分かれることが判明:
 
 1. **カスタム PDF アイコンの dark 対応欠落**: `reloadIcon` / `settingIcon` / `splashIcon` の Contents.json に `template-rendering-intent` 指定が無く、PDF の色がそのまま使われている。SwiftUI 側で `.foregroundColor(.primary)` を当てても効いていない (TimerView.swift:75, 80)。
-2. **ハードコードされた gray / white**: TimerView / SessionStatsView / TimerControlsView の計 ~10 箇所で `Color(red: ..., ..., ...)` や `Color.white` を直接指定しており、ダークモードに追従しない。
+2. **ハードコードされた gray / white**: TimerView の 2 箇所 (line 55, 66) で `Color(red: ..., ..., ...)` を直接指定しており、ダークモードに追従しない。(Explore 時点では SessionStatsView / TimerControlsView にも ~8 箇所見つかったが、それらは dead code と判明したため scope 外)
 3. **Color asset は完備済だが未活用**: `Assets.xcassets/Colors/` に `TextPrimary` / `BackgroundSecondary` 等 14 色が dark variant 込みで定義済だが、view 側で参照されていない。
 
 ### Issue #27: ビルド番号などユーザに見せる必要のない情報は不要
@@ -23,10 +23,12 @@ Explore 結果から根本原因が 3 レイヤーに分かれることが判明
 
 ## スコープ
 
-ブレストの結果 **B 案 (アイコン + 主要画面の明らかな記述バグ)** に決定:
+ブレストの結果 **B 案 (アイコン + 主要画面の明らかな記述バグ)** に決定。
+さらに plan 作成段階で実コード確認した結果、`SessionStatsView` と `TimerControlsView` が **どこからも参照されていない dead code** であることが判明 (`6096505 Implement TimerView Modernization with TDD` で書かれたが wire-up されていない)。これらを修正してもユーザー画面に変化が無いため、scope 外に移動した。
 
 - ✅ アイコン: `reloadIcon` / `settingIcon` の template-rendering 化
-- ✅ TimerView / SessionStatsView / TimerControlsView の hardcoded gray/white を semantic color へ置換
+- ✅ TimerView (live) の hardcoded gray を `.primary`/`.secondary` へ置換 (line 55, 66)
+- ❌ SessionStatsView / TimerControlsView の修正 — **dead code のため除外** (削除や wire-up は別 issue で扱う)
 - ❌ ViewModel の circle button color (`getColor1`〜`4`) — 別 issue で扱う (C 案領域)
 - ❌ splashIcon の dark variant — launch screen 専用で runtime ダークモード問題に無関係
 - ❌ 全 hardcoded 色の design token 移行 — C 案領域、今回は実施しない
@@ -55,27 +57,16 @@ Explore 結果から根本原因が 3 レイヤーに分かれることが判明
 
 ### B. Hardcoded color 置換 (Issue #26 色部分)
 
-ハイブリッド方針 — テキスト系は SwiftUI built-in (`.primary`/`.secondary`)、背景系は project の semantic asset を使う。
+ハイブリッド方針 — テキスト系は SwiftUI built-in (`.primary`/`.secondary`)。今回は live コードに該当する箇所のみ修正。
 
-| ファイル                 | 行    | Before                                         | After                              |
-|-------------------------|------|------------------------------------------------|------------------------------------|
-| TimerView.swift         | 55   | `Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9)` (timer 文字) | `.primary.opacity(0.9)`            |
-| TimerView.swift         | 66   | `Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9)` (本日カウント)  | `.secondary.opacity(0.9)`          |
-| SessionStatsView.swift  | 22   | `Color(red: 0.3, green: 0.3, blue: 0.3)` (stat 数字)                 | `.primary`                         |
-| SessionStatsView.swift  | 35   | `Color.white.opacity(0.9)` (カード背景)                                | `Color("BackgroundSecondary")`     |
-| SessionStatsView.swift  | 49   | `Color(red: 0.3, green: 0.3, blue: 0.3)` (週平均数字)                | `.primary`                         |
-| SessionStatsView.swift  | 62   | `Color.white.opacity(0.9)` (カード背景)                                | `Color("BackgroundSecondary")`     |
-| TimerControlsView.swift | 52-53| `Color.white.opacity(0.3)` / `Color.white.opacity(0.1)` (stroke)       | `.primary.opacity(0.3)` / `.primary.opacity(0.1)` |
-| TimerControlsView.swift | 78   | `Color.gray.opacity(0.2)` (reset 背景)                                 | `.secondary.opacity(0.2)`          |
-| TimerControlsView.swift | 83   | `Color.gray.opacity(0.8)` (reset icon)                                 | `.secondary.opacity(0.8)`          |
+| ファイル                 | 行  | Before                                                                | After                              |
+|-------------------------|-----|----------------------------------------------------------------------|------------------------------------|
+| TimerView.swift         | 55  | `Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9)` (timer 文字) | `.primary.opacity(0.9)`            |
+| TimerView.swift         | 66  | `Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9)` (本日カウント)  | `.secondary.opacity(0.9)`          |
 
 #### 設計判断: なぜハイブリッドか
 - `.primary` / `.secondary` は OS が light/dark で適切にコントラストを保証する標準色。テキスト用途では project asset を新設するより信頼性が高い。
-- カード背景は project 固有の brand color が必要なため `BackgroundSecondary` asset を使う。これは既に dark variant 付きで定義済。
-- stroke の `Color.white.opacity(...)` は dark 背景でも見える可能性があるが light モードで全く見えないバグになっている。`.primary.opacity(...)` にすると両モードで適切なコントラスト。
-
-#### Opacity の扱い
-SessionStatsView の背景 `Color.white.opacity(0.9)` → `Color("BackgroundSecondary")` で **opacity は外す**。理由: `BackgroundSecondary` asset は light/dark の双方で意図された色がチューニング済のため、追加の opacity は不要 (むしろ下地が透けて意図しない見た目になる)。screenshot で違和感があれば 0.95 等を後追いで足す。
+- カード背景や stroke の置換は live コードに該当箇所が無いため今回は対象外。発見した dead code の SessionStatsView / TimerControlsView は別 issue で扱う。
 
 ### C. ビルド/バージョン表示削除 (Issue #27)
 
@@ -111,7 +102,8 @@ SessionStatsView の背景 `Color.white.opacity(0.9)` → `Color("BackgroundSeco
 
 ## リスク・残課題
 
-- **ViewModel の circle button color 未対応**: ダークモードで円ボタンの色が浮く可能性が残る。別 issue (例: "Issue #26 後続: ViewModel の circle button を dark mode 対応") を triage 段階で作成済かを後で確認。無ければ別途立てる。
+- **ViewModel の circle button color 未対応**: ダークモードで円ボタンの色が浮く可能性が残る。別 issue として triage 段階で作成済かを後で確認。無ければ別途立てる。
+- **dead code (SessionStatsView / TimerControlsView) の扱い保留**: 削除 or wire-up 判断は別 issue で行う。本 PR では触らない。
 - **splashIcon は対象外**: 起動画面は一瞬しか出ないため優先度低。気になるようなら後続 issue。
 - **template-rendering 化で PDF の元色が失われる**: reloadIcon / settingIcon は元々シンプルな線画 (推定) なのでこの方針で問題ないはずだが、screenshot で確認する。万一複雑な配色 PDF だった場合は方針 C (dark variant PDF 追加) に切り替える必要あり。
 

--- a/docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md
+++ b/docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md
@@ -1,0 +1,121 @@
+# Issue #26 + #27: ダークモード視認性改善 + ビルド情報表示削除 — Design
+
+- **Date**: 2026-05-24
+- **Author**: Shinya (with Claude Opus 4.7)
+- **Status**: Approved (brainstorming completed)
+- **Related Issues**: [#26](https://github.com/es0612/LeafTimer/issues/26), [#27](https://github.com/es0612/LeafTimer/issues/27)
+
+## 背景
+
+### Issue #26: ダークモードの画面が暗すぎる
+ユーザー報告: 「アイコンなど見えづらい。デザイン性が良くない」。
+Explore 結果から根本原因が 3 レイヤーに分かれることが判明:
+
+1. **カスタム PDF アイコンの dark 対応欠落**: `reloadIcon` / `settingIcon` / `splashIcon` の Contents.json に `template-rendering-intent` 指定が無く、PDF の色がそのまま使われている。SwiftUI 側で `.foregroundColor(.primary)` を当てても効いていない (TimerView.swift:75, 80)。
+2. **ハードコードされた gray / white**: TimerView / SessionStatsView / TimerControlsView の計 ~10 箇所で `Color(red: ..., ..., ...)` や `Color.white` を直接指定しており、ダークモードに追従しない。
+3. **Color asset は完備済だが未活用**: `Assets.xcassets/Colors/` に `TextPrimary` / `BackgroundSecondary` 等 14 色が dark variant 込みで定義済だが、view 側で参照されていない。
+
+### Issue #27: ビルド番号などユーザに見せる必要のない情報は不要
+`ResetSettingsSection.swift:41-63` で `CFBundleShortVersionString` と `CFBundleVersion` を Settings 画面に表示している。ユーザー向け情報として不要。
+
+### 同一 PR で扱う理由
+両者とも UI 表面のみの変更で互いに独立。コンフリクトが起きないため 1 PR にまとめてレビュー負荷を最小化する。
+
+## スコープ
+
+ブレストの結果 **B 案 (アイコン + 主要画面の明らかな記述バグ)** に決定:
+
+- ✅ アイコン: `reloadIcon` / `settingIcon` の template-rendering 化
+- ✅ TimerView / SessionStatsView / TimerControlsView の hardcoded gray/white を semantic color へ置換
+- ❌ ViewModel の circle button color (`getColor1`〜`4`) — 別 issue で扱う (C 案領域)
+- ❌ splashIcon の dark variant — launch screen 専用で runtime ダークモード問題に無関係
+- ❌ 全 hardcoded 色の design token 移行 — C 案領域、今回は実施しない
+
+## 設計
+
+### A. アイコン修正 (Issue #26 アイコン部分)
+
+**対象ファイル**:
+- `app/LeafTimer/App/Assets.xcassets/reloadIcon.imageset/Contents.json`
+- `app/LeafTimer/App/Assets.xcassets/settingIcon.imageset/Contents.json`
+
+**変更**: `properties` ブロックを追加し `template-rendering-intent: template` を指定。
+
+```json
+{
+  "images" : [ { "filename" : "reloadIcon.pdf", "idiom" : "universal" } ],
+  "info" : { "author" : "xcode", "version" : 1 },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}
+```
+
+**Swift 側**: 変更不要。`TimerView.swift:75,80` の `.foregroundColor(.primary)` がこの設定変更で初めて有効化される。
+
+### B. Hardcoded color 置換 (Issue #26 色部分)
+
+ハイブリッド方針 — テキスト系は SwiftUI built-in (`.primary`/`.secondary`)、背景系は project の semantic asset を使う。
+
+| ファイル                 | 行    | Before                                         | After                              |
+|-------------------------|------|------------------------------------------------|------------------------------------|
+| TimerView.swift         | 55   | `Color(red: 0.65, green: 0.65, blue: 0.65, opacity: 0.9)` (timer 文字) | `.primary.opacity(0.9)`            |
+| TimerView.swift         | 66   | `Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.9)` (本日カウント)  | `.secondary.opacity(0.9)`          |
+| SessionStatsView.swift  | 22   | `Color(red: 0.3, green: 0.3, blue: 0.3)` (stat 数字)                 | `.primary`                         |
+| SessionStatsView.swift  | 35   | `Color.white.opacity(0.9)` (カード背景)                                | `Color("BackgroundSecondary")`     |
+| SessionStatsView.swift  | 49   | `Color(red: 0.3, green: 0.3, blue: 0.3)` (週平均数字)                | `.primary`                         |
+| SessionStatsView.swift  | 62   | `Color.white.opacity(0.9)` (カード背景)                                | `Color("BackgroundSecondary")`     |
+| TimerControlsView.swift | 52-53| `Color.white.opacity(0.3)` / `Color.white.opacity(0.1)` (stroke)       | `.primary.opacity(0.3)` / `.primary.opacity(0.1)` |
+| TimerControlsView.swift | 78   | `Color.gray.opacity(0.2)` (reset 背景)                                 | `.secondary.opacity(0.2)`          |
+| TimerControlsView.swift | 83   | `Color.gray.opacity(0.8)` (reset icon)                                 | `.secondary.opacity(0.8)`          |
+
+#### 設計判断: なぜハイブリッドか
+- `.primary` / `.secondary` は OS が light/dark で適切にコントラストを保証する標準色。テキスト用途では project asset を新設するより信頼性が高い。
+- カード背景は project 固有の brand color が必要なため `BackgroundSecondary` asset を使う。これは既に dark variant 付きで定義済。
+- stroke の `Color.white.opacity(...)` は dark 背景でも見える可能性があるが light モードで全く見えないバグになっている。`.primary.opacity(...)` にすると両モードで適切なコントラスト。
+
+#### Opacity の扱い
+SessionStatsView の背景 `Color.white.opacity(0.9)` → `Color("BackgroundSecondary")` で **opacity は外す**。理由: `BackgroundSecondary` asset は light/dark の双方で意図された色がチューニング済のため、追加の opacity は不要 (むしろ下地が透けて意図しない見た目になる)。screenshot で違和感があれば 0.95 等を後追いで足す。
+
+### C. ビルド/バージョン表示削除 (Issue #27)
+
+**対象**: `app/LeafTimer/View/Settings/ResetSettingsSection.swift:41-63`
+
+**変更**: System セクションの VStack ブロックを丸ごと削除。`Bundle.main.infoDictionary` への参照もそこにしか無いため、Settings 画面からはアプリバージョン情報が完全に消える。
+
+### D. 検証
+
+`ios-simulator-app-verification` skill に従い:
+
+1. `make tests` で既存ユニットテストの実行 (色値を直接テストしている箇所が無いことを確認)
+2. `xcrun simctl boot` で iPhone 17 シミュレータ起動
+3. アプリビルド → install
+4. `xcrun simctl ui booted appearance light` → TimerView と Settings 画面 screenshot 撮影
+5. `xcrun simctl ui booted appearance dark` → 同 screenshot
+6. 計 4 枚 (TimerView light/dark, Settings light/dark) を PR description に添付
+
+### E. テスト戦略
+
+- **ユニットテスト**: 既存テストへの影響をまず確認。色値テストが無ければ追加せず通過確認のみ。
+- **UI snapshot test**: プロジェクトに導入されておらず、今回も追加しない。
+- **手動検証**: 上記 D の screenshot を一次エビデンスとする。
+
+### F. PR / Commit 戦略
+
+- **ブランチ名**: `feature/issue-26-27-dark-mode-improvements`
+- **Commit 分割** (レビュー容易性のため):
+  1. `Issue #27: ResetSettingsSection からバージョン/ビルド表示を削除`
+  2. `Issue #26: reloadIcon/settingIcon を template 化 + hardcoded color を semantic asset へ置換`
+- **PR タイトル**: `Issue #26 #27: ダークモード視認性改善 + ビルド情報表示削除`
+- **PR 本文**: `Closes #26, Closes #27` + screenshot 4 枚 + scope の B 案を選んだ理由 + 残課題 (C 案領域は別 issue へ)
+
+## リスク・残課題
+
+- **ViewModel の circle button color 未対応**: ダークモードで円ボタンの色が浮く可能性が残る。別 issue (例: "Issue #26 後続: ViewModel の circle button を dark mode 対応") を triage 段階で作成済かを後で確認。無ければ別途立てる。
+- **splashIcon は対象外**: 起動画面は一瞬しか出ないため優先度低。気になるようなら後続 issue。
+- **template-rendering 化で PDF の元色が失われる**: reloadIcon / settingIcon は元々シンプルな線画 (推定) なのでこの方針で問題ないはずだが、screenshot で確認する。万一複雑な配色 PDF だった場合は方針 C (dark variant PDF 追加) に切り替える必要あり。
+
+## 関連
+
+- 過去 spec: `docs/superpowers/specs/2026-05-23-xcode-cloud-migration-design.md`
+- Issue triage: 同セッションで `daily-issue-triage` skill により #27 + #26 を選択


### PR DESCRIPTION
## Summary

- **Issue #27**: Settings 画面から不要な Version / Build 表示を削除
- **Issue #26**: TimerView ツールバーアイコン (reloadIcon / settingIcon) の dark mode 視認性を修正、タイマー文字色をシステム標準 `.primary` / `.secondary` に置換

## 設計判断

スコープ B 案 (アイコン + 主要画面の明らかな記述バグ) を採用。設計詳細は `docs/superpowers/specs/2026-05-24-dark-mode-and-hide-build-info-design.md` を、実装計画は `docs/superpowers/plans/2026-05-24-issue-26-27-dark-mode-improvements.md` を参照。

plan 作成段階で `SessionStatsView` / `TimerControlsView` が dead code (commit 6096505 で書かれたが wire-up されていない) と判明したため、それらの色修正は本 PR の scope 外とし、別 issue 候補とする。

### 主な変更点

- `app/LeafTimer/App/Assets.xcassets/{reloadIcon,settingIcon}.imageset/Contents.json` に `template-rendering-intent: template` を追加 → 既存の `.foregroundColor(.primary)` が初めて効くようになる
- `app/LeafTimer/View/TimerView.swift:55,66` の `Color(red: 0.65, ...)` / `Color(red: 0.5, ...)` を `.primary.opacity(0.9)` / `.secondary.opacity(0.9)` に置換
- `app/LeafTimer/View/Settings/ResetSettingsSection.swift` の App Information VStack (Version / Build 表示) を削除

## Verification

- `cd app && make tests` が **TEST SUCCEEDED**: 109 tests / 0 failures
- iPhone 17 Simulator (iOS latest) で light + dark の TimerView 表示を screenshot 取得済 (本 PR コメントに貼り付け予定)
- Settings 画面の Version/Build 削除は grep で確認済 (CFBundleVersion / CFBundleShortVersionString への参照ゼロ)

## Test plan

- [x] cd app && make unit-tests で既存テスト pass
- [x] iPhone 17 Simulator で light mode 起動 → TimerView screenshot
- [x] iPhone 17 Simulator で dark mode 起動 → TimerView screenshot
- [x] reloadIcon / settingIcon が light / dark の両方で視認可能なこと目視確認
- [x] Settings 画面から Version / Build 表示が消えていること grep + ビルド成功で確認

## Out-of-scope

- ViewModel `getColor1`〜`getColor4` の dark mode 対応 (CircleButton の visual)
- splashIcon の dark variant
- SessionStatsView / TimerControlsView の dead code 削除 or wire-up
- 全 hardcoded 色を design token へ統一する大規模 refactor

これらは別 issue 候補。

Closes #26
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)