### PR TITLE
fix(ci): Xcode Cloud で CI_WORKSPACE 未定義によるビルド失敗を修正

### DIFF
--- a/app/ci_scripts/ci_post_clone.sh
+++ b/app/ci_scripts/ci_post_clone.sh
@@ -10,7 +10,10 @@ set -euo pipefail
 
 echo "==> ci_post_clone.sh: start"
 
-APP_DIR="${CI_WORKSPACE}/app"
+# Xcode Cloud は CI_WORKSPACE を提供しない (実環境で unbound variable で失敗)。
+# スクリプト自身の位置から app/ を解決し env var 依存を排除する。
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 echo "==> Restoring Keys.plist"
 echo "${KEYS_PLIST_BASE64}" | base64 -d > "${APP_DIR}/Keys.plist"


### PR DESCRIPTION
## Summary

- Xcode Cloud のビルドが `ci_post_clone.sh: line 13: CI_WORKSPACE: unbound variable` で失敗していた
- Xcode Cloud は `CI_WORKSPACE` env var を提供していない (Apple 公式 doc 旧版に記載はあるが実環境で undefined)
- スクリプト自身の位置から `app/` を解決する形式に変更し、env var 依存を排除

## Root cause

ビルドログ (2026-05-26 8:50 開始の Archive - iOS):

```
==> ci_post_clone.sh: start
/Volumes/workspace/repository/app/ci_scripts/ci_post_clone.sh: line 13: CI_WORKSPACE: unbound variable
Command exited with non-zero exit-code: 1
```

`set -euo pipefail` の `-u` (unbound variable) で即時 exit していた。

## Fix

`${BASH_SOURCE[0]}` から `app/ci_scripts/` の親 (= `app/`) を解決:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
```

env var 仕様変更に追従不要・最も robust な選択。CLAUDE.md の振り返り「マネージド CI runner は preinstall を保証しない」の方針 (CI 環境への依存最小化) と整合。

## Test plan

- [x] `bash -n` で syntax check OK
- [x] ローカル dry-run: 相対呼び出しで `APP_DIR=/.../LeafTimer/app` 取得
- [x] ローカル dry-run: Xcode Cloud と同じ絶対パス呼び出しでも同上
- [ ] master merge 後の Xcode Cloud Archive ビルドで成功確認

## Related

- 直前の Issue #31 (Package.resolved 修正) では `.gitignore` の whitelist だけが正解で、ci_post_clone.sh は触っていなかったため、この root cause が表に出てきた
- Issue #13 Part B-E で初期実装時に `CI_WORKSPACE` を使った経緯あり (旧 Apple doc 由来と推測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)