### PR TITLE
release: v1.5 (MARKETING_VERSION 1.4 → 1.5)

### DIFF
--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -909,7 +909,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_ASSET_PATHS = "\"LeafTimer/View/Preview Content\"";
 				DEVELOPMENT_LANGUAGE = ja;
 				DEVELOPMENT_TEAM = UUD4WPFJTD;
@@ -919,7 +919,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.ema.LeafTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.9;
@@ -934,7 +934,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_ASSET_PATHS = "\"LeafTimer/View/Preview Content\"";
 				DEVELOPMENT_LANGUAGE = ja;
 				DEVELOPMENT_TEAM = UUD4WPFJTD;
@@ -944,7 +944,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.ema.LeafTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.9;


### PR DESCRIPTION
## Summary

App Store Connect から ITMS-90186 / ITMS-90062 で reject されたため、リリース版のバージョンを bump する。

## ASC reject の詳細

提出ビルド: Version 1.4 / Build 5

- **ITMS-90186**: The train version '1.4' is closed for new build submissions
- **ITMS-90062**: The value for key CFBundleShortVersionString [1.4] in the Info.plist file must contain a higher version than that of the previously approved version [1.4]

→ 1.4 はすでに App Store で ready for sale。新しい submission には 1.4 より大きい marketing version が必須。

## Version bump

| key | old | new | 根拠 |
|---|---|---|---|
| `MARKETING_VERSION` | 1.4 | **1.5** | ASC last approved = 1.4 (v1.4 tag)。user-facing 改善が複数あるので minor bump |
| `CURRENT_PROJECT_VERSION` | 24 | **25** | 安全側で bump。ASC メールでは Build 5 と食い違いがある (Xcode Cloud の自動 build# 管理が独立) が、`-showBuildSettings` ベースでは 25 が反映される |

## v1.4 以降の user-facing 変更

- Issue #26: ダークモード視認性改善 (アイコン + タイマー画面テキスト色)
- Issue #27: Settings 画面からバージョン/ビルド表示を削除
- Issue #13 Part A: AdMob テスト/本番 ID 自動切替

(その他は CI / テスト / docs のみで内部変更)

## Test plan

- [x] `grep "MARKETING_VERSION|CURRENT_PROJECT_VERSION" project.pbxproj` で旧値 (1.4 / 24) の残骸なし
- [x] `xcodebuild -showBuildSettings` で `MARKETING_VERSION = 1.5` / `CURRENT_PROJECT_VERSION = 25` を確認
- [ ] master merge 後の Xcode Cloud Archive ビルドが成功
- [ ] TestFlight 提出後に ITMS-90186 / 90062 が再発しない
- [ ] App Store Connect 側で Version 1.5 の train が新規作成される

## Notes

- 直前の PR #34 (ci_post_clone.sh の CI_WORKSPACE 修正) で Xcode Cloud の Archive ステップは到達できるようになった
- 今回 reject されたのは Archive 後の "Prepare Build for App Store Connect" ステップ → version 不整合のみが残課題
- merge 後に `git tag -a v1.5 -m "Release v1.5" && git push origin v1.5` を実行することを忘れずに (release-version-bump-check skill の共通 mistake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)