### PR TITLE
fix(ci): Claude Code Review が PR にコメント投稿できるよう権限と prompt を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

PR #34 / #35 で Claude Code Review workflow は **success 終了**していたが、PR にレビューコメントが投稿されない事象を修正する。

## Root cause (2 件)

### A. `permissions: pull-requests: read` ではコメント投稿できない

GitHub Actions の `GITHUB_TOKEN` は `permissions:` で指定した範囲しか叩けない。`pull-requests: read` だと PR の取得しかできず、`POST /repos/{owner}/{repo}/issues/{number}/comments` は権限不足で silent fail する。

→ `pull-requests: write` / `issues: write` に変更。

### B. `--comment` フラグなしでは Claude はコメントを post しない

`skill list` の `code-review` 説明:
> code-review: ... **Pass `--comment` to post findings as inline PR comments.**

現状の prompt:
```yaml
prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
```

→ `--comment` 無しだと Claude はレビューを実行するが結果を console output のみで終わり、post step は `No buffered inline comments` と出力して空で完了する。

→ `--comment` を追加。

## 該当ログ抜粋 (PR #35 の run 26426226609)

```
"subtype": "success",
"is_error": false,
"total_cost_usd": 0.5382,
"permission_denials_count": 1   ← 権限不足の denial
...
No buffered inline comments     ← post step に何も渡ってない
```

## Changes

| ファイル | 変更 |
|---|---|
| `.github/workflows/claude-code-review.yml` | permissions write 化 + prompt に `--comment` |
| `.github/workflows/claude.yml` | permissions write 化 (@claude メンション応答用) |

## Test plan

- [x] `gh run list` で claude-code-review job が success で終わるが PR コメントが空であることを確認 (PR #34, #35)
- [x] `gh run view --log` で `No buffered inline comments` 出力を確認
- [ ] **本 PR のオープン時に claude-code-review workflow が走り、本 PR にレビューコメントが投稿される** ← 動作確認ポイント
- [ ] 次回以降の PR でも自動で Claude レビューが付く

## Notes

- 本 PR の workflow が走る時、まだ修正前の workflow.yml (master 版) が使われるため、本 PR 自体のレビューコメントは投稿されない**可能性が高い**。pull_request イベントで触ったブランチの workflow が使われるはずだが、permissions の解釈は workflow をマージしたタイミングに依存することがある。merge 後の次の PR で本確認するのが確実。
- `pull-requests: write` を付与しても、Claude が自発的に書き換える範囲は `--comment` 経由のコメント投稿のみ。コード自体への push 権限 (`contents: write`) は付けていないので副作用は最小。

🤖 Generated with [Claude Code](https://claude.com/claude-code)