### PR TITLE
fix(history): 履歴画面が0表示に戻る回帰を修正 (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 
 - Xcode Cloud Workflow の "scheme may only exist locally" 警告は、scheme が shared + git tracked + remote push 済みなら基本 false positive。Why: 実 build log で `Cannot find scheme` が出ていなければ build 自体は通っているので、警告メッセージそのものを起点に scheme 設定を弄ると無駄な往復が増える。How to apply: 次回 Xcode Cloud の scheme 警告対応時は、scheme 設定を疑う前に最新 build log を `Cannot find scheme` 等のエラー文字列で grep し、build error が無ければ警告は無視する。
 - `app/.gitignore` の `*.xcworkspace` ワイルドカードは `xcshareddata/swiftpm/Package.resolved` を巻き込む。Why: Issue #31 で SPM 依存追加時に `Package.resolved` が commit されず Xcode Cloud の dependency 解決が失敗した実害があった。How to apply: SPM 依存を追加・更新する時は `git status` に `Package.resolved` が出るかを必ず確認し、出ていなければ `git add -f` で強制 add するか `.gitignore` の whitelist (`!**/Package.resolved`) を追加する。
+- 新規 Swift ファイルを Xcode project に追加すると `project.pbxproj` の children グループが未ソート状態になる。`make sort` を**最終 commit の前に**実行すること。実行を忘れると PR 作成直後に「1 uncommitted change」warning として表面化し、cosmetic 差分の追い commit が 1 回余計に発生する (Issue #8 で `make sort` 漏れが PR 化後に発覚した)。How to apply: 新規ファイル追加を含むブランチでは push/PR 前のセルフチェックに `make sort && git status` を入れる。
 
 ### 効率化ルール
 
@@ -95,4 +96,5 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 - `superpowers:subagent-driven-development` を採用する時、Plan の Task が「観察+編集+検証+commit」のような小粒で密接結合なら、Task ごとに subagent を dispatch せず**複数 Task を 1 subagent に full text で束ねて渡す**。レビューはまとめて 2 段階 (spec compliance → code quality) で実施する。Why: 個別 dispatch のオーバーヘッド (context 渡し / Tool 再 load / agent boot) > 実行コストになることがある。Issue #16 で Plan の Task 2-6 を 1 subagent に束ね、起動コストを抑えつつ品質ゲートは両 reviewer で確保できた。
 - Agent tool 経由で subagent に `cd app && make unit-tests` を実行させる時、Bash の `timeout` を明示的に `600000` (10 分) に設定するよう subagent 指示書に書く。Why: xcodebuild + simulator boot + test 実行で 2〜5 分かかるため、Bash のデフォルト 2 分でタイムアウトすると、せっかくのテスト実行が無駄になる。
 - マネージド CI runner (Xcode Cloud / GitHub-hosted runner 等) は Apple 同梱以外の言語ツールチェイン (CocoaPods / Bundler 等) の preinstall を保証しない。`ci_post_clone.sh` のような CI hook の冒頭で必要なツールを明示的に `brew install` / `gem install` してから本処理に入る。Why: ローカルでは `pod install` が動くため見落としやすく、初回本番ビルド時に silent break する。How to apply: 新規 CI hook を書く時、ローカル前提のツール (cocoapods / bundler / yarn / poetry 等) があるかチェックし、ある場合は `set -euo pipefail` 配下で install ステップを先頭に追加する。
+- SwiftLint 組み込み `empty_count` rule は tuple の Int field など `.isEmpty` を使えない箇所でも `.count == 0` を検出する。新規コードでは可能な限り `.isEmpty` を使い、Int field 等で不可避な場合のみ `// swiftlint:disable:next empty_count` で 1 行 suppress する。Why: Issue #8 では test 内の `(date, count)` tuple 比較で違反が `make tests` 段階まで検出されず、最後に suppress 対応が発生した。
 

--- a/app/LeafTimer/View/TimerView.swift
+++ b/app/LeafTimer/View/TimerView.swift
@@ -84,7 +84,7 @@ struct TimerView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         NavigationLink(
                             destination: HistoryView(
-                                viewModel: timerViewModel.makeHistoryViewModel()
+                                viewModel: timerViewModel.historyViewModel
                             )
                         ) {
                             Image(systemName: "chart.bar.fill")

--- a/app/LeafTimer/ViewModel/TimerViewModel.swift
+++ b/app/LeafTimer/ViewModel/TimerViewModel.swift
@@ -211,9 +211,13 @@ class TimerViewModel: ObservableObject {
         longestStreak = stats.longestStreak
     }
 
-    // MARK: - Navigation Factories
+    // MARK: - Navigation
 
-    func makeHistoryViewModel() -> HistoryViewModel {
-        HistoryViewModel(repository: sessionStatsRepository)
-    }
+    // HistoryView の ViewModel は単一インスタンスを保持する。
+    // タイマー稼働中は currentTimeSecond の @Published 更新で TimerView.body が毎秒
+    // 再評価され、eager NavigationLink の destination が作り直される。その都度
+    // HistoryViewModel を新規生成すると load() 済みの内容が空 VM に差し替わり、
+    // 履歴が 0 表示に戻る (Issue #40)。lazy var で同一インスタンスを渡し続けることで
+    // 再描画に耐え、再ナビゲーション時は HistoryView.onAppear の load() が最新化する。
+    lazy var historyViewModel = HistoryViewModel(repository: sessionStatsRepository)
 }

--- a/app/LeafTimerTests/TimerCoreLogicSpec.swift
+++ b/app/LeafTimerTests/TimerCoreLogicSpec.swift
@@ -192,6 +192,23 @@ class TimerCoreLogicSpec: QuickSpec {
                 }
             }
 
+            // MARK: - History navigation (Issue #40 regression)
+
+            context("History navigation") {
+                // Issue #40: タイマー稼働中は TimerView.body が毎秒再評価され、eager
+                // NavigationLink の destination が作り直される。HistoryView の VM をその都度
+                // 新規生成すると、load() 済みの内容が空 VM に差し替わり履歴が 0 表示に戻る。
+                // 同一インスタンスを返すことで再描画に耐える。
+                it("HistoryViewModel は同一インスタンスを返す") {
+                    let (vm, _, _, _, _, _) = makeViewModel()
+
+                    let first = vm.historyViewModel
+                    let second = vm.historyViewModel
+
+                    expect(first).to(beIdenticalTo(second))
+                }
+            }
+
             // MARK: - Memory management
 
             context("Memory management") {


### PR DESCRIPTION
## 概要
Issue #40 の回帰バグ修正です。履歴画面で「一瞬正しい回数のグラフが出るが、すぐ0表示に戻る」症状を解消します。直近マージの #37（履歴可視化）で混入した回帰です。

## 根本原因
- タイマー稼働中は `TimerViewModel.currentTimeSecond`（`@Published`）が毎秒減算され、`TimerView.body` が**毎秒再評価**される
- 履歴ボタンは eager な `NavigationLink(destination:)` で、body 再評価のたびに destination (`HistoryView`) を作り直す
- `makeHistoryViewModel()` が**毎回新規** `HistoryViewModel` を生成していたため、`onAppear` で `load()` 済みのインスタンスが空 VM に差し替わる
- `onAppear` は初回しか発火しないため再ロードされず、`last7Days` 等が初期値（0）に戻る

→ 「一瞬（次の tick まで）正しい → 0 に変わる」という症状と一致。
※「一瞬は正しく出る」＝ストアにデータは在る証拠であり、日付フォーマット不一致・migration 消去の説は排除済み。

## 修正
`TimerViewModel.makeHistoryViewModel()`（毎回新規生成）を `lazy var historyViewModel`（単一インスタンス）に変更。再描画でも同一インスタンスを渡し続けるため表示が維持され、再ナビゲーション時は `HistoryView.onAppear` の `load()` が最新化する。`TimerViewModel` は AppDelegate で app ライフタイム保持されるため lazy var は安定。

## テスト
- 回帰テストを `TimerCoreLogicSpec` に追加（`historyViewModel` が同一インスタンスを返す）
- **RED→GREEN 確認済み**（修正前: 異なるインスタンス → 修正後: 同一）
- 全 **129 tests pass**（16 skipped, 0 failures）、ビルド成功、SwiftLint 新規違反なし

## ⚠️ 手動確認をお願いします
自動テストは「機構（VM が再生成されない）」の検証であり、画面が実際にリセットしなくなったかは別です。`xcrun simctl` はタップ不可で履歴画面への遷移を自動化できないため、以下を手動でご確認ください:

1. タイマーを**スタート（稼働状態に）**する
2. 履歴画面へ遷移する（非0の回数がある状態で）
3. **1秒以上**待つ
4. 0 に戻らなければ修正成功 ✅

※タイマー停止中は再レンダが起きずバグが再現しないので、必ず稼働中で確認してください。

## follow-up（本PR対象外）
- iOS 17 idiom の `.navigationDestination` への移行は別途検討

## 補足
- `chore(docs)` コミットで CLAUDE.md に前セッションの振り返り2点を追記（#40 とは独立の housekeeping）

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)