### PR TITLE
chore(release): 輸出コンプライアンスを事前設定 (#38)

### DIFF
--- a/app/LeafTimer/Info.plist
+++ b/app/LeafTimer/Info.plist
@@ -22,6 +22,8 @@
 	<string>ca-app-pub-9706471521661305~4450977179</string>
 	<key>GADIsAdManagerApp</key>
 	<string>true</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>SKAdNetworkItems</key>


### PR DESCRIPTION
## 概要
Issue #38 対応。App Store Connect の提出ごとに表示される**輸出コンプライアンス（暗号化）の質問**を事前設定でスキップできるようにします。

## 変更内容
`app/LeafTimer/Info.plist` に以下を追加:
```xml
<key>ITSAppUsesNonExemptEncryption</key>
<false/>
```

## なぜ `NO`（false）が正しいか
本アプリが利用する暗号化は Firebase / AdMob 等の**標準 HTTPS（TLS）のみ**で、Apple の輸出規制上「非適用(non-exempt)暗号化」には該当しません。独自暗号化や規制対象アルゴリズムは未使用のため `NO` が正しい申告です。

## 効果
- 次回以降の提出で ASC の暗号化コンプライアンス質問が自動的に解決され、毎回の手入力が不要になる

## 検証
- `plutil -lint LeafTimer/Info.plist` → `OK`
- `plutil -extract ITSAppUsesNonExemptEncryption raw` → `false`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)