### PR TITLE
chore(i18n): 未使用ローカライズキー timer.todays_count を削除 (#44)

### DIFF
--- a/app/LeafTimer/App/en.lproj/Localizable.strings
+++ b/app/LeafTimer/App/en.lproj/Localizable.strings
@@ -5,7 +5,6 @@
 
 // MARK: - Timer View
 "timer.title" = "Pomodoro";
-"timer.todays_count" = "Today's Pomodoros: ";
 "timer.stat.today" = "Today %d";
 "timer.stat.streak" = "Streak %d";
 

--- a/app/LeafTimer/App/ja.lproj/Localizable.strings
+++ b/app/LeafTimer/App/ja.lproj/Localizable.strings
@@ -7,7 +7,6 @@
 
 // MARK: - Timer View
 "timer.title" = "ポモドーロ";
-"timer.todays_count" = "今日のポモドーロ数：";
 "timer.stat.today" = "今日 %d";
 "timer.stat.streak" = "連続 %d";
 


### PR DESCRIPTION
## 概要

未使用ローカライズキー `timer.todays_count`（dead string）を削除します。Issue #39 のトップ画面ステータス刷新時に発覚しました（#39 以前から未使用）。

## 変更内容

- `app/LeafTimer/App/ja.lproj/Localizable.strings` から `timer.todays_count` を削除
- `app/LeafTimer/App/en.lproj/Localizable.strings` から `timer.todays_count` を削除

## 検証

- `grep -rn "todays_count" app/` で **参照ゼロ**（Swift / .strings / .xcstrings すべて）を確認
- `make tests`（sort + lint + unit-tests）→ **134 tests, 0 failures**（`** TEST SUCCEEDED **`）
- 挙動変化なし（cosmetic cleanup）

## 規模

XS

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)