### PR TITLE
feat(tooling): gitignore-doctor で .gitignore の意図ズレを検出 (#11)

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -47,3 +47,7 @@ tests: precheck sort lint unit-tests
 
 beta:
 	@/usr/bin/time fastlane beta
+
+gitignore-check:
+	@echo "Running gitignore-doctor..."
+	@ruby bin/gitignore-doctor.rb

--- a/app/Makefile
+++ b/app/Makefile
@@ -50,4 +50,5 @@ beta:
 
 gitignore-check:
 	@echo "Running gitignore-doctor..."
+	@ruby bin/test_gitignore_doctor.rb
 	@ruby bin/gitignore-doctor.rb

--- a/app/bin/gitignore-doctor-expectations.txt
+++ b/app/bin/gitignore-doctor-expectations.txt
@@ -1,0 +1,23 @@
+# gitignore-doctor expectations — declares intended keep/ignore paths.
+# Verified by `make gitignore-check` (bin/gitignore-doctor.rb).
+#
+# `keep:`   = must be committable (NOT ignored). Catches #31-type accidents
+#             (a needed file swallowed by a broad wildcard).
+# `ignore:` = must be ignored. Catches #9-type anchor-leak accidents
+#             (an unanchored pattern matching at any depth).
+#
+# Paths are REPO-ROOT-relative (no leading slash). DIRECTORY-intent paths MUST
+# end with a trailing slash (e.g. "app/Pods/") so check-ignore matches a
+# directory-only pattern even when the path is absent on disk (fresh clone /
+# before `make install`). FILE-intent paths have no trailing slash.
+# Lines starting with '#' and blank lines are skipped.
+
+# --- #31: Package.resolved must survive the *.xcworkspace ignore ladder (FILE) ---
+keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+# --- #9: plan docs must NOT be swallowed by an unanchored 'plans' (DIR) ---
+keep:   docs/superpowers/plans/
+
+# --- paths that genuinely must stay ignored (DIRs → trailing slash) ---
+ignore: app/Pods/
+ignore: plans/

--- a/app/bin/gitignore-doctor.rb
+++ b/app/bin/gitignore-doctor.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# gitignore-doctor: verify that .gitignore behaves as intended.
+#
+# Reads bin/gitignore-doctor-expectations.txt (keep:/ignore: lines), then for
+# each path runs `git check-ignore --no-index -v -- <path>` AT THE REPO ROOT and
+# decides ignored/not via the matched rule (never the exit code). Reports any
+# mismatch and exits non-zero. See the design doc + MEMORY for the rationale.
+#
+# Usage:
+#   ruby bin/gitignore-doctor.rb     # run checks, non-zero exit on violation
+#
+# Exit code 0 = all expectations met (or fixture absent/empty); 1 = violation
+# or a git failure.
+
+require 'open3'
+require_relative 'gitignore_doctor'
+
+SCRIPT_DIR    = __dir__                                   # app/bin
+FIXTURE_FILE  = File.join(SCRIPT_DIR, 'gitignore-doctor-expectations.txt')
+
+# Resolve the repository top level so check-ignore path args are root-relative.
+def repo_root
+  root, status = Open3.capture2('git', 'rev-parse', '--show-toplevel')
+  raise 'not inside a git repository' unless status.success?
+
+  root.strip
+end
+
+# Run `git check-ignore --no-index -v -- <path>` at the repo root, return its
+# stdout (0 or 1 line). check-ignore exits 1 when nothing matches; that is a
+# normal "not ignored" result, NOT an error, so we don't treat exit on it.
+def check_ignore_output(root, path)
+  out, _err, _status = Open3.capture3(
+    'git', '-C', root, 'check-ignore', '--no-index', '-v', '--', path
+  )
+  out
+end
+
+# --- run --------------------------------------------------------------------
+
+unless File.exist?(FIXTURE_FILE)
+  puts "⚠️  gitignore-doctor: no expectations file (#{File.basename(FIXTURE_FILE)}); skipped"
+  exit 0
+end
+
+expectations = GitignoreDoctor.parse_expectations(File.read(FIXTURE_FILE))
+
+if expectations.empty?
+  puts '✅ gitignore-doctor: no expectations declared (nothing to check)'
+  exit 0
+end
+
+begin
+  root = repo_root
+rescue RuntimeError => e
+  warn "❌ gitignore-doctor: #{e.message}"
+  exit 1
+end
+
+results = expectations.each_with_object({}) do |exp, acc|
+  acc[exp[:path]] = check_ignore_output(root, exp[:path])
+end
+
+violations = GitignoreDoctor.evaluate(expectations, results)
+
+if violations.empty?
+  puts "✅ gitignore-doctor: #{expectations.size} expectation(s) satisfied"
+  exit 0
+else
+  warn "❌ gitignore-doctor: #{violations.size} violation(s):"
+  violations.each do |v|
+    warn "   - [#{v[:kind]}] #{v[:path]}: #{v[:message]}"
+  end
+  warn '   → fix the .gitignore rule or update bin/gitignore-doctor-expectations.txt'
+  exit 1
+end

--- a/app/bin/gitignore-doctor.rb
+++ b/app/bin/gitignore-doctor.rb
@@ -45,7 +45,12 @@ unless File.exist?(FIXTURE_FILE)
   exit 0
 end
 
-expectations = GitignoreDoctor.parse_expectations(File.read(FIXTURE_FILE))
+begin
+  expectations = GitignoreDoctor.parse_expectations(File.read(FIXTURE_FILE))
+rescue GitignoreDoctor::ParseError => e
+  warn "❌ gitignore-doctor: #{e.message}"
+  exit 1
+end
 
 if expectations.empty?
   puts '✅ gitignore-doctor: no expectations declared (nothing to check)'
@@ -54,7 +59,7 @@ end
 
 begin
   root = repo_root
-rescue RuntimeError => e
+rescue RuntimeError, Errno::ENOENT => e
   warn "❌ gitignore-doctor: #{e.message}"
   exit 1
 end

--- a/app/bin/gitignore_doctor.rb
+++ b/app/bin/gitignore_doctor.rb
@@ -50,4 +50,29 @@ module GitignoreDoctor
     pattern = meta.sub(/\A[^:]*:\d+:/, '')   # strip "source:line:"
     !pattern.start_with?('!')
   end
+
+  # Compare expectations against per-path `git check-ignore` outputs.
+  # `results` maps a path String to the raw check-ignore output String.
+  # Returns a list of violations: [{path:, kind:, message:}].
+  #   keep   + ignored      -> violation (#31: a must-keep path is ignored)
+  #   ignore + not ignored  -> violation (#9: a must-ignore path leaks through)
+  def self.evaluate(expectations, results)
+    expectations.filter_map do |exp|
+      output = results.fetch(exp[:path], '')
+      is_ignored = ignored?(output)
+
+      case exp[:kind]
+      when :keep
+        next unless is_ignored
+
+        { path: exp[:path], kind: :keep,
+          message: "expected to be committable but is IGNORED by .gitignore" }
+      when :ignore
+        next if is_ignored
+
+        { path: exp[:path], kind: :ignore,
+          message: "expected to be ignored but is NOT ignored by .gitignore" }
+      end
+    end
+  end
 end

--- a/app/bin/gitignore_doctor.rb
+++ b/app/bin/gitignore_doctor.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Pure helpers for gitignore-doctor. Kept free of I/O so they can be unit-tested
+# (see test_gitignore_doctor.rb). The CLI glue lives in bin/gitignore-doctor.rb.
+#
+# Oracle: `git check-ignore --no-index -v -- <path>` OUTPUT (not exit code).
+# See docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md and MEMORY
+# feedback-gitignore-check-ignore-semantics for why exit code is unusable.
+module GitignoreDoctor
+  EXPECTATION_LINE = /\A(keep|ignore):\s*(.+)\z/.freeze
+
+  # Parse the expectations fixture text into [{kind: :keep|:ignore, path: String}].
+  # Skips blank lines and lines starting with '#'. Normalizes a leading './' and a
+  # trailing '/' so the same path written either way compares equal.
+  def self.parse_expectations(text)
+    text.each_line.filter_map do |line|
+      stripped = line.strip
+      next if stripped.empty? || stripped.start_with?('#')
+
+      m = stripped.match(EXPECTATION_LINE)
+      next unless m
+
+      { kind: m[1].to_sym, path: normalize_path(m[2].strip) }
+    end
+  end
+
+  # Normalize a repo-relative path: drop a leading './'. A trailing '/' is KEPT
+  # on purpose — it signals directory intent, which git check-ignore needs to
+  # match a directory-only pattern (e.g. "Pods/") when the path is absent on disk
+  # (fresh clone / before `make install`). Stripping it would cause an
+  # environment-dependent false "NOT ignored". See the design doc's trap section.
+  def self.normalize_path(path)
+    path.sub(%r{\A\./}, '')
+  end
+end

--- a/app/bin/gitignore_doctor.rb
+++ b/app/bin/gitignore_doctor.rb
@@ -9,20 +9,47 @@
 module GitignoreDoctor
   EXPECTATION_LINE = /\A(keep|ignore):\s*(.+)\z/.freeze
 
+  # Raised when the fixture contains a non-blank, non-comment line that is not a
+  # well-formed 'keep:'/'ignore:' expectation. We hard-fail (rather than warn or
+  # silently drop) so a typo like 'keeep:' cannot make the checker quietly skip a
+  # path it was supposed to guard — "thinking you're protected when you're not".
+  class ParseError < StandardError; end
+
   # Parse the expectations fixture text into [{kind: :keep|:ignore, path: String}].
   # Skips blank lines and lines starting with '#'. Normalizes away a leading './';
   # a trailing '/' is preserved on purpose (see normalize_path) — it signals
   # directory intent.
+  #
+  # Any non-blank, non-comment line that is NOT a well-formed expectation raises
+  # ParseError (with line number + content). A path containing whitespace is also
+  # treated as malformed: gitignore paths normally have no spaces, so this catches
+  # an accidental inline comment (e.g. 'keep: foo # because' parsing the path as
+  # 'foo # because') instead of guarding the wrong, longer string.
   def self.parse_expectations(text)
-    text.each_line.filter_map do |line|
+    entries = []
+    malformed = []
+
+    text.each_line.with_index(1) do |line, lineno|
       stripped = line.strip
       next if stripped.empty? || stripped.start_with?('#')
 
       m = stripped.match(EXPECTATION_LINE)
-      next unless m
+      path = m && normalize_path(m[2].strip)
 
-      { kind: m[1].to_sym, path: normalize_path(m[2].strip) }
+      if m.nil? || path.match?(/\s/)
+        malformed << "line #{lineno}: #{stripped}"
+        next
+      end
+
+      entries << { kind: m[1].to_sym, path: path }
     end
+
+    unless malformed.empty?
+      raise ParseError,
+            "malformed expectation line(s):\n  #{malformed.join("\n  ")}"
+    end
+
+    entries
   end
 
   # Normalize a repo-relative path: drop a leading './'. A trailing '/' is KEPT

--- a/app/bin/gitignore_doctor.rb
+++ b/app/bin/gitignore_doctor.rb
@@ -32,4 +32,22 @@ module GitignoreDoctor
   def self.normalize_path(path)
     path.sub(%r{\A\./}, '')
   end
+
+  # Decide whether a path is ignored, from the OUTPUT of
+  # `git check-ignore --no-index -v -- <path>`. The output is 0 or 1 line:
+  #   "<source>:<line>:<pattern>\t<path>"
+  # We never use the exit code (it returns 0 even for a '!' negation).
+  #   - empty output            -> not ignored (no rule matched)
+  #   - matched pattern is '!…'  -> not ignored (effective whitelist)
+  #   - any other matched rule   -> ignored
+  # Split on TAB first, then strip the leading "source:line:" so a pattern that
+  # itself contains ':' is parsed correctly.
+  def self.ignored?(check_ignore_output)
+    line = check_ignore_output.to_s.strip
+    return false if line.empty?
+
+    meta = line.split("\t", 2).first        # "<source>:<line>:<pattern>"
+    pattern = meta.sub(/\A[^:]*:\d+:/, '')   # strip "source:line:"
+    !pattern.start_with?('!')
+  end
 end

--- a/app/bin/gitignore_doctor.rb
+++ b/app/bin/gitignore_doctor.rb
@@ -5,13 +5,14 @@
 #
 # Oracle: `git check-ignore --no-index -v -- <path>` OUTPUT (not exit code).
 # See docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md and MEMORY
-# feedback-gitignore-check-ignore-semantics for why exit code is unusable.
+# feedback_gitignore_check_ignore_semantics.md for why exit code is unusable.
 module GitignoreDoctor
   EXPECTATION_LINE = /\A(keep|ignore):\s*(.+)\z/.freeze
 
   # Parse the expectations fixture text into [{kind: :keep|:ignore, path: String}].
-  # Skips blank lines and lines starting with '#'. Normalizes a leading './' and a
-  # trailing '/' so the same path written either way compares equal.
+  # Skips blank lines and lines starting with '#'. Normalizes away a leading './';
+  # a trailing '/' is preserved on purpose (see normalize_path) — it signals
+  # directory intent.
   def self.parse_expectations(text)
     text.each_line.filter_map do |line|
       stripped = line.strip

--- a/app/bin/test_gitignore_doctor.rb
+++ b/app/bin/test_gitignore_doctor.rb
@@ -45,4 +45,33 @@ class GitignoreDoctorTest < Minitest::Test
     text = "\n# only comments\n   \n"
     assert_equal [], GitignoreDoctor.parse_expectations(text)
   end
+
+  # --- ignored? -------------------------------------------------------------
+
+  def test_ignored_false_for_empty_output
+    refute GitignoreDoctor.ignored?('')
+  end
+
+  def test_ignored_false_when_last_rule_is_negation
+    # whitelist が効いている: マッチ行のパターンが '!' で始まる
+    out = ".gitignore:6:!ws/xcshareddata/swiftpm/Package.resolved\tws/xcshareddata/swiftpm/Package.resolved"
+    refute GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_true_for_normal_rule
+    # 通常ルールがマッチ = ignore されている
+    out = ".gitignore:1:ws/\tws/xcshareddata/swiftpm/Package.resolved"
+    assert GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_handles_pattern_containing_colon
+    # パターン自体に ':' を含んでも TAB 先割りで壊れない (脆い末尾マッチ回帰防止)
+    out = ".gitignore:3:foo:bar\tpath/foo:bar"
+    assert GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_trailing_newline_tolerated
+    out = ".gitignore:1:plans\tdocs/superpowers/plans\n"
+    assert GitignoreDoctor.ignored?(out)
+  end
 end

--- a/app/bin/test_gitignore_doctor.rb
+++ b/app/bin/test_gitignore_doctor.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Unit tests for the pure functions in gitignore_doctor.rb.
+# Run: ruby bin/test_gitignore_doctor.rb
+require 'minitest/autorun'
+require_relative 'gitignore_doctor'
+
+class GitignoreDoctorTest < Minitest::Test
+  # --- parse_expectations ---------------------------------------------------
+
+  def test_parse_expectations_classifies_keep_and_ignore
+    text = <<~TXT
+      # comment line
+      keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+      ignore: app/Pods
+    TXT
+    result = GitignoreDoctor.parse_expectations(text)
+    assert_equal(
+      [
+        { kind: :keep,   path: 'app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved' },
+        { kind: :ignore, path: 'app/Pods' }
+      ],
+      result
+    )
+  end
+
+  def test_parse_expectations_strips_leading_dot_but_keeps_trailing_slash
+    # 先頭 './' は吸収。末尾 '/' は dir 意図として保持し check-ignore にそのまま渡す
+    # (不在ディレクトリを安定 match させるため。設計の「dir パターン × 不在」の罠対策)
+    text = "ignore: ./plans/\nkeep: docs/superpowers/plans/\nkeep: a/File.txt\n"
+    result = GitignoreDoctor.parse_expectations(text)
+    assert_equal(
+      [
+        { kind: :ignore, path: 'plans/' },
+        { kind: :keep,   path: 'docs/superpowers/plans/' },
+        { kind: :keep,   path: 'a/File.txt' }
+      ],
+      result
+    )
+  end
+
+  def test_parse_expectations_skips_blank_and_comment_lines
+    text = "\n# only comments\n   \n"
+    assert_equal [], GitignoreDoctor.parse_expectations(text)
+  end
+end

--- a/app/bin/test_gitignore_doctor.rb
+++ b/app/bin/test_gitignore_doctor.rb
@@ -46,6 +46,30 @@ class GitignoreDoctorTest < Minitest::Test
     assert_equal [], GitignoreDoctor.parse_expectations(text)
   end
 
+  def test_parse_expectations_raises_on_malformed_line
+    # 'keep:'/'ignore:' のタイポ等を黙って捨てると「守っているつもりで守れていない」
+    # 事故になるため、malformed 行は hard fail (raise) する。
+    text = "keep: app/ok\nkeeep: app/typo\n"
+    err = assert_raises(GitignoreDoctor::ParseError) do
+      GitignoreDoctor.parse_expectations(text)
+    end
+    # メッセージに行番号と該当行を含めて気づけるようにする
+    assert_includes err.message, 'line 2'
+    assert_includes err.message, 'keeep: app/typo'
+  end
+
+  def test_parse_expectations_raises_on_path_with_space_inline_comment
+    # path にスペースを含む行は malformed として raise する。
+    # gitignore のパスにスペースは通常無く、inline '# comment' の混入検出になる
+    # (例 'keep: foo # because' は path が 'foo # because' になってしまう)。
+    text = "keep: foo # because\n"
+    err = assert_raises(GitignoreDoctor::ParseError) do
+      GitignoreDoctor.parse_expectations(text)
+    end
+    assert_includes err.message, 'line 1'
+    assert_includes err.message, 'foo # because'
+  end
+
   # --- ignored? -------------------------------------------------------------
 
   def test_ignored_false_for_empty_output

--- a/app/bin/test_gitignore_doctor.rb
+++ b/app/bin/test_gitignore_doctor.rb
@@ -74,4 +74,37 @@ class GitignoreDoctorTest < Minitest::Test
     out = ".gitignore:1:plans\tdocs/superpowers/plans\n"
     assert GitignoreDoctor.ignored?(out)
   end
+
+  # --- evaluate -------------------------------------------------------------
+
+  def test_evaluate_flags_keep_that_is_ignored
+    # #31 シナリオ: keep したい Package.resolved が ignore されている
+    expectations = [{ kind: :keep, path: 'ws/swiftpm/Package.resolved' }]
+    results = { 'ws/swiftpm/Package.resolved' => ".gitignore:1:ws/\tws/swiftpm/Package.resolved" }
+    violations = GitignoreDoctor.evaluate(expectations, results)
+    assert_equal 1, violations.size
+    assert_equal :keep, violations.first[:kind]
+    assert_equal 'ws/swiftpm/Package.resolved', violations.first[:path]
+  end
+
+  def test_evaluate_flags_ignore_that_is_not_ignored
+    # #9 シナリオ: ignore したい plans が ignore されていない (アンカー修正後に取りこぼし)
+    expectations = [{ kind: :ignore, path: 'plans' }]
+    results = { 'plans' => '' } # no rule matched
+    violations = GitignoreDoctor.evaluate(expectations, results)
+    assert_equal 1, violations.size
+    assert_equal :ignore, violations.first[:kind]
+  end
+
+  def test_evaluate_no_violations_when_all_expectations_met
+    expectations = [
+      { kind: :keep,   path: 'docs/plans' },
+      { kind: :ignore, path: 'plans' }
+    ]
+    results = {
+      'docs/plans' => '',                                  # keep: not ignored -> OK
+      'plans'      => ".gitignore:1:plans\tplans"          # ignore: ignored  -> OK
+    }
+    assert_empty GitignoreDoctor.evaluate(expectations, results)
+  end
 end

--- a/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
+++ b/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
@@ -1,0 +1,599 @@
+# gitignore-doctor Implementation Plan (Issue #11)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.gitignore` の意図（keep/ignore したいパス）と git の実挙動のズレを `make gitignore-check` で機械検出し、#9（アンカー漏れ）/ #31（whitelist 漏れ）型の事故を再発防止する。
+
+**Architecture:** 既存 `xcode-precheck` と同じ 2 層 + テスト構造。純粋関数モジュール `gitignore_doctor.rb`（I/O なし・minitest 対象）と、リポジトリルートで `git check-ignore --no-index -v` を path ごとに叩く実行スクリプト `gitignore-doctor.rb` に分離。判定は exit code を使わず、出力の last-rule が `!`（negation）で始まるかでパースする。
+
+**Tech Stack:** Ruby（標準ライブラリ + minitest のみ・gem 不要）、git `check-ignore --no-index -v`、GNU/BSD make。
+
+---
+
+## 前提（着手前に必読）
+
+- ブランチ `feature/11-gitignore-doctor` は作成済み、設計（`docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md`）はコミット済み。
+- スクリプトは `app/` ディレクトリではなく **リポジトリルート**で `git` を実行する必要がある
+  （`check-ignore` の path 引数を repo ルート相対で扱うため）。実行スクリプトが repo ルートを
+  特定して `Dir.chdir` する（後述 Task 4）。
+- minitest は Ruby 同梱（`require 'minitest/autorun'`）。`test_xcode_precheck.rb` と同じ。
+- `gitignore_doctor.rb`（アンダースコア）= 純粋ロジック、`gitignore-doctor.rb`（ハイフン）= 実行。
+- このプロジェクトの shell は **zsh**。`${PIPESTATUS[0]}` は使わない（空を返す）。テスト成否は
+  minitest の出力末尾（`0 failures, 0 errors` / `Failure`）と終了コードで判定する。
+
+## File Structure
+
+| ファイル | 責務 |
+|---|---|
+| `app/bin/gitignore_doctor.rb` | 純粋関数モジュール `GitignoreDoctor`: `parse_expectations`, `ignored?`, `evaluate` |
+| `app/bin/test_gitignore_doctor.rb` | 上記の minitest ユニットテスト |
+| `app/bin/gitignore-doctor.rb` | 実行: fixture 読込 → repo ルートで `git check-ignore` → `evaluate` → 表示・exit |
+| `app/bin/gitignore-doctor-expectations.txt` | 期待 fixture（`keep:` / `ignore:` 行） |
+| `app/Makefile` | `gitignore-check` ターゲット追加（既存ファイルの末尾に追記） |
+
+---
+
+## Task 1: 純粋関数 `parse_expectations`
+
+fixture テキストを `[{kind:, path:}]` にパースする。`#` コメント・空行スキップ、`keep:` / `ignore:` 行を分類し、path の先頭 `./`・末尾 `/` を吸収する。
+
+**Files:**
+- Create: `app/bin/gitignore_doctor.rb`
+- Test: `app/bin/test_gitignore_doctor.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+`app/bin/test_gitignore_doctor.rb` を新規作成:
+
+```ruby
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Unit tests for the pure functions in gitignore_doctor.rb.
+# Run: ruby bin/test_gitignore_doctor.rb
+require 'minitest/autorun'
+require_relative 'gitignore_doctor'
+
+class GitignoreDoctorTest < Minitest::Test
+  # --- parse_expectations ---------------------------------------------------
+
+  def test_parse_expectations_classifies_keep_and_ignore
+    text = <<~TXT
+      # comment line
+      keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+      ignore: app/Pods
+    TXT
+    result = GitignoreDoctor.parse_expectations(text)
+    assert_equal(
+      [
+        { kind: :keep,   path: 'app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved' },
+        { kind: :ignore, path: 'app/Pods' }
+      ],
+      result
+    )
+  end
+
+  def test_parse_expectations_normalizes_leading_dot_and_trailing_slash
+    text = "ignore: ./plans/\nkeep: docs/superpowers/plans/\n"
+    result = GitignoreDoctor.parse_expectations(text)
+    assert_equal(
+      [
+        { kind: :ignore, path: 'plans' },
+        { kind: :keep,   path: 'docs/superpowers/plans' }
+      ],
+      result
+    )
+  end
+
+  def test_parse_expectations_skips_blank_and_comment_lines
+    text = "\n# only comments\n   \n"
+    assert_equal [], GitignoreDoctor.parse_expectations(text)
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: FAIL — `cannot load such file -- .../gitignore_doctor` (モジュール未作成) または `NoMethodError`。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`app/bin/gitignore_doctor.rb` を新規作成:
+
+```ruby
+# frozen_string_literal: true
+
+# Pure helpers for gitignore-doctor. Kept free of I/O so they can be unit-tested
+# (see test_gitignore_doctor.rb). The CLI glue lives in bin/gitignore-doctor.rb.
+#
+# Oracle: `git check-ignore --no-index -v -- <path>` OUTPUT (not exit code).
+# See docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md and MEMORY
+# feedback-gitignore-check-ignore-semantics for why exit code is unusable.
+module GitignoreDoctor
+  EXPECTATION_LINE = /\A(keep|ignore):\s*(.+)\z/.freeze
+
+  # Parse the expectations fixture text into [{kind: :keep|:ignore, path: String}].
+  # Skips blank lines and lines starting with '#'. Normalizes a leading './' and a
+  # trailing '/' so the same path written either way compares equal.
+  def self.parse_expectations(text)
+    text.each_line.filter_map do |line|
+      stripped = line.strip
+      next if stripped.empty? || stripped.start_with?('#')
+
+      m = stripped.match(EXPECTATION_LINE)
+      next unless m
+
+      { kind: m[1].to_sym, path: normalize_path(m[2].strip) }
+    end
+  end
+
+  # Normalize a repo-relative path: drop a leading './' and a trailing '/'.
+  def self.normalize_path(path)
+    path = path.sub(%r{\A\./}, '')
+    path = path.sub(%r{/\z}, '')
+    path
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: PASS — `3 runs, ... 0 failures, 0 errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bin/gitignore_doctor.rb app/bin/test_gitignore_doctor.rb
+git commit -m "feat(gitignore-doctor): #11 parse_expectations 純粋関数 + テスト"
+```
+
+---
+
+## Task 2: 純粋関数 `ignored?`
+
+`git check-ignore --no-index -v -- <path>` の生出力（0 or 1 行）を受け取り、ignore されているかを返す。exit code は使わない。TAB 先割り → 行頭 `source:line:` を strip してパターンを取り、`!` 始まりなら NOT ignored。
+
+**Files:**
+- Modify: `app/bin/gitignore_doctor.rb`
+- Test: `app/bin/test_gitignore_doctor.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+`test_gitignore_doctor.rb` の `parse_expectations` テスト群の下（クラス内）に追記:
+
+```ruby
+  # --- ignored? -------------------------------------------------------------
+
+  def test_ignored_false_for_empty_output
+    refute GitignoreDoctor.ignored?('')
+  end
+
+  def test_ignored_false_when_last_rule_is_negation
+    # whitelist が効いている: マッチ行のパターンが '!' で始まる
+    out = ".gitignore:6:!ws/xcshareddata/swiftpm/Package.resolved\tws/xcshareddata/swiftpm/Package.resolved"
+    refute GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_true_for_normal_rule
+    # 通常ルールがマッチ = ignore されている
+    out = ".gitignore:1:ws/\tws/xcshareddata/swiftpm/Package.resolved"
+    assert GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_handles_pattern_containing_colon
+    # パターン自体に ':' を含んでも TAB 先割りで壊れない (脆い末尾マッチ回帰防止)
+    out = ".gitignore:3:foo:bar\tpath/foo:bar"
+    assert GitignoreDoctor.ignored?(out)
+  end
+
+  def test_ignored_trailing_newline_tolerated
+    out = ".gitignore:1:plans\tdocs/superpowers/plans\n"
+    assert GitignoreDoctor.ignored?(out)
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: FAIL — `NoMethodError: undefined method 'ignored?' for GitignoreDoctor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`gitignore_doctor.rb` の `module GitignoreDoctor` 内、`normalize_path` の下に追記:
+
+```ruby
+  # Decide whether a path is ignored, from the OUTPUT of
+  # `git check-ignore --no-index -v -- <path>`. The output is 0 or 1 line:
+  #   "<source>:<line>:<pattern>\t<path>"
+  # We never use the exit code (it returns 0 even for a '!' negation).
+  #   - empty output            -> not ignored (no rule matched)
+  #   - matched pattern is '!…'  -> not ignored (effective whitelist)
+  #   - any other matched rule   -> ignored
+  # Split on TAB first, then strip the leading "source:line:" so a pattern that
+  # itself contains ':' is parsed correctly.
+  def self.ignored?(check_ignore_output)
+    line = check_ignore_output.to_s.strip
+    return false if line.empty?
+
+    meta = line.split("\t", 2).first        # "<source>:<line>:<pattern>"
+    pattern = meta.sub(/\A[^:]*:\d+:/, '')   # strip "source:line:"
+    !pattern.start_with?('!')
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: PASS — `8 runs, ... 0 failures, 0 errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bin/gitignore_doctor.rb app/bin/test_gitignore_doctor.rb
+git commit -m "feat(gitignore-doctor): #11 ignored? 出力パース (negation aware・exit code 不使用)"
+```
+
+---
+
+## Task 3: 純粋関数 `evaluate`
+
+期待リストと「path → check-ignore 出力」の Hash を受け取り、違反リストを返す。keep が ignored なら違反（#31）、ignore が NOT ignored なら違反（#9）。
+
+**Files:**
+- Modify: `app/bin/gitignore_doctor.rb`
+- Test: `app/bin/test_gitignore_doctor.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+`test_gitignore_doctor.rb` のクラス内に追記:
+
+```ruby
+  # --- evaluate -------------------------------------------------------------
+
+  def test_evaluate_flags_keep_that_is_ignored
+    # #31 シナリオ: keep したい Package.resolved が ignore されている
+    expectations = [{ kind: :keep, path: 'ws/swiftpm/Package.resolved' }]
+    results = { 'ws/swiftpm/Package.resolved' => ".gitignore:1:ws/\tws/swiftpm/Package.resolved" }
+    violations = GitignoreDoctor.evaluate(expectations, results)
+    assert_equal 1, violations.size
+    assert_equal :keep, violations.first[:kind]
+    assert_equal 'ws/swiftpm/Package.resolved', violations.first[:path]
+  end
+
+  def test_evaluate_flags_ignore_that_is_not_ignored
+    # #9 シナリオ: ignore したい plans が ignore されていない (アンカー修正後に取りこぼし)
+    expectations = [{ kind: :ignore, path: 'plans' }]
+    results = { 'plans' => '' } # no rule matched
+    violations = GitignoreDoctor.evaluate(expectations, results)
+    assert_equal 1, violations.size
+    assert_equal :ignore, violations.first[:kind]
+  end
+
+  def test_evaluate_no_violations_when_all_expectations_met
+    expectations = [
+      { kind: :keep,   path: 'docs/plans' },
+      { kind: :ignore, path: 'plans' }
+    ]
+    results = {
+      'docs/plans' => '',                                  # keep: not ignored -> OK
+      'plans'      => ".gitignore:1:plans\tplans"          # ignore: ignored  -> OK
+    }
+    assert_empty GitignoreDoctor.evaluate(expectations, results)
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: FAIL — `NoMethodError: undefined method 'evaluate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`gitignore_doctor.rb` の `ignored?` の下に追記:
+
+```ruby
+  # Compare expectations against per-path `git check-ignore` outputs.
+  # `results` maps a path String to the raw check-ignore output String.
+  # Returns a list of violations: [{path:, kind:, message:}].
+  #   keep   + ignored      -> violation (#31: a must-keep path is ignored)
+  #   ignore + not ignored  -> violation (#9: a must-ignore path leaks through)
+  def self.evaluate(expectations, results)
+    expectations.filter_map do |exp|
+      output = results.fetch(exp[:path], '')
+      is_ignored = ignored?(output)
+
+      case exp[:kind]
+      when :keep
+        next unless is_ignored
+
+        { path: exp[:path], kind: :keep,
+          message: "expected to be committable but is IGNORED by .gitignore" }
+      when :ignore
+        next if is_ignored
+
+        { path: exp[:path], kind: :ignore,
+          message: "expected to be ignored but is NOT ignored by .gitignore" }
+      end
+    end
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: PASS — `11 runs, ... 0 failures, 0 errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bin/gitignore_doctor.rb app/bin/test_gitignore_doctor.rb
+git commit -m "feat(gitignore-doctor): #11 evaluate (keep/ignore 両方向の違反検出)"
+```
+
+---
+
+## Task 4: 実行スクリプト `gitignore-doctor.rb`
+
+fixture を読み、repo ルートで各 path に `git check-ignore --no-index -v` を実行、`evaluate` で違反を集めて表示・exit code を返す。
+
+**Files:**
+- Create: `app/bin/gitignore-doctor.rb`
+
+- [ ] **Step 1: Write the execution script**
+
+`app/bin/gitignore-doctor.rb` を新規作成:
+
+```ruby
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# gitignore-doctor: verify that .gitignore behaves as intended.
+#
+# Reads bin/gitignore-doctor-expectations.txt (keep:/ignore: lines), then for
+# each path runs `git check-ignore --no-index -v -- <path>` AT THE REPO ROOT and
+# decides ignored/not via the matched rule (never the exit code). Reports any
+# mismatch and exits non-zero. See the design doc + MEMORY for the rationale.
+#
+# Usage:
+#   ruby bin/gitignore-doctor.rb     # run checks, non-zero exit on violation
+#
+# Exit code 0 = all expectations met (or fixture absent/empty); 1 = violation
+# or a git failure.
+
+require 'open3'
+require_relative 'gitignore_doctor'
+
+SCRIPT_DIR    = __dir__                                   # app/bin
+FIXTURE_FILE  = File.join(SCRIPT_DIR, 'gitignore-doctor-expectations.txt')
+
+# Resolve the repository top level so check-ignore path args are root-relative.
+def repo_root
+  root, status = Open3.capture2('git', 'rev-parse', '--show-toplevel')
+  raise 'not inside a git repository' unless status.success?
+
+  root.strip
+end
+
+# Run `git check-ignore --no-index -v -- <path>` at the repo root, return its
+# stdout (0 or 1 line). check-ignore exits 1 when nothing matches; that is a
+# normal "not ignored" result, NOT an error, so we don't treat exit on it.
+def check_ignore_output(root, path)
+  out, _err, _status = Open3.capture3(
+    'git', '-C', root, 'check-ignore', '--no-index', '-v', '--', path
+  )
+  out
+end
+
+# --- run --------------------------------------------------------------------
+
+unless File.exist?(FIXTURE_FILE)
+  puts "⚠️  gitignore-doctor: no expectations file (#{File.basename(FIXTURE_FILE)}); skipped"
+  exit 0
+end
+
+expectations = GitignoreDoctor.parse_expectations(File.read(FIXTURE_FILE))
+
+if expectations.empty?
+  puts '✅ gitignore-doctor: no expectations declared (nothing to check)'
+  exit 0
+end
+
+begin
+  root = repo_root
+rescue RuntimeError => e
+  warn "❌ gitignore-doctor: #{e.message}"
+  exit 1
+end
+
+results = expectations.each_with_object({}) do |exp, acc|
+  acc[exp[:path]] = check_ignore_output(root, exp[:path])
+end
+
+violations = GitignoreDoctor.evaluate(expectations, results)
+
+if violations.empty?
+  puts "✅ gitignore-doctor: #{expectations.size} expectation(s) satisfied"
+  exit 0
+else
+  warn "❌ gitignore-doctor: #{violations.size} violation(s):"
+  violations.each do |v|
+    warn "   - [#{v[:kind]}] #{v[:path]}: #{v[:message]}"
+  end
+  warn '   → fix the .gitignore rule or update bin/gitignore-doctor-expectations.txt'
+  exit 1
+end
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x app/bin/gitignore-doctor.rb`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit (実行確認は Task 5 の fixture 投入後)**
+
+```bash
+git add app/bin/gitignore-doctor.rb
+git commit -m "feat(gitignore-doctor): #11 実行スクリプト (repo ルートで check-ignore)"
+```
+
+---
+
+## Task 5: 初期 fixture + 実行確認（green）
+
+リポジトリの既知の意図を fixture に書き、実際に `make` 経由ではなく直接実行して green を確認する。
+
+**Files:**
+- Create: `app/bin/gitignore-doctor-expectations.txt`
+
+- [ ] **Step 1: Write the fixture**
+
+`app/bin/gitignore-doctor-expectations.txt` を新規作成:
+
+```text
+# gitignore-doctor expectations — declares intended keep/ignore paths.
+# Verified by `make gitignore-check` (bin/gitignore-doctor.rb).
+#
+# `keep:`   = must be committable (NOT ignored). Catches #31-type accidents
+#             (a needed file swallowed by a broad wildcard).
+# `ignore:` = must be ignored. Catches #9-type anchor-leak accidents
+#             (an unanchored pattern matching at any depth).
+#
+# Paths are REPO-ROOT-relative (no leading slash). Lines starting with '#'
+# and blank lines are skipped.
+
+# --- #31: Package.resolved must survive the *.xcworkspace ignore ladder ---
+keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+# --- #9: plan docs must NOT be swallowed by an unanchored 'plans' ---
+keep:   docs/superpowers/plans
+
+# --- paths that genuinely must stay ignored ---
+ignore: app/Pods
+ignore: plans
+```
+
+- [ ] **Step 2: Run the doctor directly and verify green**
+
+Run: `cd app && ruby bin/gitignore-doctor.rb`
+Expected: `✅ gitignore-doctor: 4 expectation(s) satisfied`, exit 0.
+
+確認: `echo $?` が `0`。
+
+- [ ] **Step 3: Sanity-check the RED path (一時的に fixture を壊す)**
+
+`keep:` の Package.resolved 行が IGNORED なら RED になることを一時確認する。
+fixture を一時編集して、確実に ignore される `app/Pods` を `keep:` にしてみる:
+
+Run:
+```bash
+cd app
+ruby -e 'puts File.read("bin/gitignore-doctor-expectations.txt").sub("ignore: app/Pods","keep: app/Pods")' > /tmp/expect-broken.txt
+cp bin/gitignore-doctor-expectations.txt /tmp/expect-orig.txt
+cp /tmp/expect-broken.txt bin/gitignore-doctor-expectations.txt
+ruby bin/gitignore-doctor.rb; echo "exit=$?"
+cp /tmp/expect-orig.txt bin/gitignore-doctor-expectations.txt
+```
+Expected: `❌ gitignore-doctor: 1 violation(s):` と `[keep] app/Pods: ...IGNORED...`、`exit=1`。
+その後 fixture が元に戻っていること（`git diff --stat app/bin/gitignore-doctor-expectations.txt` が空）を確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/bin/gitignore-doctor-expectations.txt
+git commit -m "feat(gitignore-doctor): #11 初期 expectations fixture (#9/#31 の意図を明記)"
+```
+
+---
+
+## Task 6: Makefile に `gitignore-check` ターゲット追加
+
+**Files:**
+- Modify: `app/Makefile`（末尾に追記。`make tests` には**入れない**）
+
+- [ ] **Step 1: Add the target**
+
+`app/Makefile` の末尾（`beta:` ブロックの後）に追記:
+
+```makefile
+
+gitignore-check:
+	@echo "Running gitignore-doctor..."
+	@ruby bin/gitignore-doctor.rb
+```
+
+- [ ] **Step 2: Run via make and verify green**
+
+Run: `cd app && make gitignore-check`
+Expected:
+```
+Running gitignore-doctor...
+✅ gitignore-doctor: 4 expectation(s) satisfied
+```
+exit 0（`echo $?` が `0`）。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Makefile
+git commit -m "feat(gitignore-doctor): #11 make gitignore-check ターゲット追加"
+```
+
+---
+
+## Task 7: 仕上げ（README 追記 + 最終確認）
+
+**Files:**
+- Modify: `app/bin/` に既存 README があれば追記。無ければスキップ（新規 README は作らない=YAGNI）。
+
+- [ ] **Step 1: bin/ の既存ドキュメント有無を確認**
+
+Run: `ls app/bin/*.md 2>/dev/null; grep -rl "xcode-precheck" app/*.md docs/*.md 2>/dev/null | head`
+- 既存の bin ツール一覧ドキュメントがあれば `gitignore-check` を 1 行追記。
+- 無ければ何もしない（このタスクはスキップ）。
+
+- [ ] **Step 2: 全テスト + lint 最終確認**
+
+Run: `cd app && ruby bin/test_gitignore_doctor.rb`
+Expected: `11 runs, ... 0 failures, 0 errors`.
+
+Run: `cd app && make gitignore-check`
+Expected: `✅ gitignore-doctor: 4 expectation(s) satisfied`.
+
+- [ ] **Step 3: 新規 Ruby スクリプトに Rubocop 等の lint があるか確認**
+
+Run: `ls app/.rubocop.yml 2>/dev/null && echo "rubocop config exists" || echo "no rubocop"`
+- あれば `rubocop bin/gitignore_doctor.rb bin/gitignore-doctor.rb` を実行し違反を修正。
+- 無ければスキップ（SwiftLint は Swift 専用なので Ruby には無関係）。
+
+- [ ] **Step 4: PR 前のセルフチェック**
+
+Run: `git log --oneline master..HEAD`
+Expected: spec 2 commit + 実装 5〜6 commit が並ぶ。
+
+Run: `git status --short`
+Expected: クリーン（追跡漏れファイルなし）。
+
+> 注: 新規ファイルは Xcode project に追加しない（`app/bin/` 配下は project.pbxproj 管理外の
+> リポジトリスクリプト）。よって `make sort` / `make precheck` の pbxproj 影響は無い。
+
+---
+
+## Self-Review（plan 作成者によるチェック）
+
+- **Spec coverage**:
+  - オラクル（check-ignore --no-index -v 出力パース）→ Task 2 ✅
+  - keep/ignore 両方向の判定 → Task 3 ✅
+  - fixture 宣言形式 + repo ルート相対 → Task 1（正規化）+ Task 5 ✅
+  - repo ルートで git 実行 → Task 4（`git -C root` + `rev-parse --show-toplevel`）✅
+  - `make gitignore-check` 独立ターゲット・tests に入れない → Task 6 ✅
+  - fixture 不在/空で exit 0 → Task 4 実装 ✅
+  - keep 物理ファイル無しは判定に影響しない（`--no-index`）→ Task 4 が物理存在チェックを
+    含まないことで担保 ✅
+- **Placeholder scan**: コードは全タスクで完全。Task 7 の README/rubocop は「あれば追記/なければ
+  スキップ」と条件を明示（プレースホルダではなく分岐指示）。
+- **Type consistency**: `parse_expectations` → `[{kind:, path:}]`、`ignored?(String)→Bool`、
+  `evaluate(expectations, results:Hash)→[{path:,kind:,message:}]`。Task 3 のテストと Task 4 の
+  実行スクリプトで同じ shape を使用。違反 Hash のキー（`:path` `:kind` `:message`）も一致。

--- a/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
+++ b/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
@@ -499,7 +499,9 @@ Run:
 ```bash
 cd app
 cp bin/gitignore-doctor-expectations.txt /tmp/expect-orig.txt
-ruby -e 'puts File.read("bin/gitignore-doctor-expectations.txt").sub("ignore: app/Pods/","keep: app/Pods/")' > bin/gitignore-doctor-expectations.txt
+# ⚠️ 元ファイルを直接 `> 同じファイル` にリダイレクトすると shell が先に空にしてから
+# Ruby が読むため空になる。必ずバックアップ (/tmp/expect-orig.txt) から読むこと。
+ruby -e 'puts File.read("/tmp/expect-orig.txt").sub("ignore: app/Pods/","keep: app/Pods/")' > bin/gitignore-doctor-expectations.txt
 ruby bin/gitignore-doctor.rb; echo "exit=$?"
 cp /tmp/expect-orig.txt bin/gitignore-doctor-expectations.txt
 ```

--- a/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
+++ b/docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md
@@ -74,13 +74,16 @@ class GitignoreDoctorTest < Minitest::Test
     )
   end
 
-  def test_parse_expectations_normalizes_leading_dot_and_trailing_slash
-    text = "ignore: ./plans/\nkeep: docs/superpowers/plans/\n"
+  def test_parse_expectations_strips_leading_dot_but_keeps_trailing_slash
+    # 先頭 './' は吸収。末尾 '/' は dir 意図として保持し check-ignore にそのまま渡す
+    # (不在ディレクトリを安定 match させるため。設計の「dir パターン × 不在」の罠対策)
+    text = "ignore: ./plans/\nkeep: docs/superpowers/plans/\nkeep: a/File.txt\n"
     result = GitignoreDoctor.parse_expectations(text)
     assert_equal(
       [
-        { kind: :ignore, path: 'plans' },
-        { kind: :keep,   path: 'docs/superpowers/plans' }
+        { kind: :ignore, path: 'plans/' },
+        { kind: :keep,   path: 'docs/superpowers/plans/' },
+        { kind: :keep,   path: 'a/File.txt' }
       ],
       result
     )
@@ -129,11 +132,13 @@ module GitignoreDoctor
     end
   end
 
-  # Normalize a repo-relative path: drop a leading './' and a trailing '/'.
+  # Normalize a repo-relative path: drop a leading './'. A trailing '/' is KEPT
+  # on purpose — it signals directory intent, which git check-ignore needs to
+  # match a directory-only pattern (e.g. "Pods/") when the path is absent on disk
+  # (fresh clone / before `make install`). Stripping it would cause an
+  # environment-dependent false "NOT ignored". See the design doc's trap section.
   def self.normalize_path(path)
-    path = path.sub(%r{\A\./}, '')
-    path = path.sub(%r{/\z}, '')
-    path
+    path.sub(%r{\A\./}, '')
   end
 end
 ```
@@ -461,18 +466,21 @@ git commit -m "feat(gitignore-doctor): #11 実行スクリプト (repo ルート
 # `ignore:` = must be ignored. Catches #9-type anchor-leak accidents
 #             (an unanchored pattern matching at any depth).
 #
-# Paths are REPO-ROOT-relative (no leading slash). Lines starting with '#'
-# and blank lines are skipped.
+# Paths are REPO-ROOT-relative (no leading slash). DIRECTORY-intent paths MUST
+# end with a trailing slash (e.g. "app/Pods/") so check-ignore matches a
+# directory-only pattern even when the path is absent on disk (fresh clone /
+# before `make install`). FILE-intent paths have no trailing slash.
+# Lines starting with '#' and blank lines are skipped.
 
-# --- #31: Package.resolved must survive the *.xcworkspace ignore ladder ---
+# --- #31: Package.resolved must survive the *.xcworkspace ignore ladder (FILE) ---
 keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
-# --- #9: plan docs must NOT be swallowed by an unanchored 'plans' ---
-keep:   docs/superpowers/plans
+# --- #9: plan docs must NOT be swallowed by an unanchored 'plans' (DIR) ---
+keep:   docs/superpowers/plans/
 
-# --- paths that genuinely must stay ignored ---
-ignore: app/Pods
-ignore: plans
+# --- paths that genuinely must stay ignored (DIRs → trailing slash) ---
+ignore: app/Pods/
+ignore: plans/
 ```
 
 - [ ] **Step 2: Run the doctor directly and verify green**
@@ -484,20 +492,34 @@ Expected: `✅ gitignore-doctor: 4 expectation(s) satisfied`, exit 0.
 
 - [ ] **Step 3: Sanity-check the RED path (一時的に fixture を壊す)**
 
-`keep:` の Package.resolved 行が IGNORED なら RED になることを一時確認する。
-fixture を一時編集して、確実に ignore される `app/Pods` を `keep:` にしてみる:
+`keep:` 宣言が IGNORED なら RED になることを一時確認する。
+fixture を一時編集して、確実に ignore される `app/Pods/` を `keep:` にしてみる:
 
 Run:
 ```bash
 cd app
-ruby -e 'puts File.read("bin/gitignore-doctor-expectations.txt").sub("ignore: app/Pods","keep: app/Pods")' > /tmp/expect-broken.txt
 cp bin/gitignore-doctor-expectations.txt /tmp/expect-orig.txt
-cp /tmp/expect-broken.txt bin/gitignore-doctor-expectations.txt
+ruby -e 'puts File.read("bin/gitignore-doctor-expectations.txt").sub("ignore: app/Pods/","keep: app/Pods/")' > bin/gitignore-doctor-expectations.txt
 ruby bin/gitignore-doctor.rb; echo "exit=$?"
 cp /tmp/expect-orig.txt bin/gitignore-doctor-expectations.txt
 ```
-Expected: `❌ gitignore-doctor: 1 violation(s):` と `[keep] app/Pods: ...IGNORED...`、`exit=1`。
+Expected: `❌ gitignore-doctor: 1 violation(s):` と `[keep] app/Pods/: ...IGNORED...`、`exit=1`。
 その後 fixture が元に戻っていること（`git diff --stat app/bin/gitignore-doctor-expectations.txt` が空）を確認。
+
+- [ ] **Step 3b: Sanity-check the directory-absent scenario (環境依存 false-RED 回帰防止)**
+
+設計の核心バグ（dir パターンを不在パスにスラッシュ無しで問うと false "NOT ignored"）が
+末尾スラッシュ方式で解消されていることを scratch repo で確認する:
+
+Run:
+```bash
+TMP=$(mktemp -d); cd "$TMP"; git init -q; printf 'Pods/\n' > .gitignore
+git -C "$TMP" check-ignore --no-index -v -- Pods;  echo "noslash/absent exit=$?"   # 期待: 出力なし・exit 1
+git -C "$TMP" check-ignore --no-index -v -- Pods/; echo "slash/absent exit=$?"     # 期待: ".gitignore:1:Pods/<TAB>Pods/" ・exit 0
+rm -rf "$TMP"
+```
+Expected: スラッシュ無しは出力なし（不在で no-match）、**スラッシュ付きは matched**。
+これが fixture で `ignore: app/Pods/` と書く根拠（不在環境でも安定 ignored 判定）。
 
 - [ ] **Step 4: Commit**
 
@@ -587,6 +609,8 @@ Expected: クリーン（追跡漏れファイルなし）。
   - オラクル（check-ignore --no-index -v 出力パース）→ Task 2 ✅
   - keep/ignore 両方向の判定 → Task 3 ✅
   - fixture 宣言形式 + repo ルート相対 → Task 1（正規化）+ Task 5 ✅
+  - dir パターン × 不在パスの罠（末尾スラッシュ保持で安定 match）→ Task 1（末尾 `/` 保持）
+    + Task 5 Step 3b（不在 dir の RED 確認）✅
   - repo ルートで git 実行 → Task 4（`git -C root` + `rev-parse --show-toplevel`）✅
   - `make gitignore-check` 独立ターゲット・tests に入れない → Task 6 ✅
   - fixture 不在/空で exit 0 → Task 4 実装 ✅

--- a/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
+++ b/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
@@ -87,6 +87,9 @@ expectations.txt              per-path に git へ問い合わせ
 git は「親ディレクトリが除外されていれば配下の `!` 再 include は無効」というルールも
 **評価済みの最終結果**としてマッチ行に反映する（実機確認: 階段状 whitelist を `ws/` 一発に
 簡略化すると、`!…Package.resolved` ではなく効いている `ws/` がマッチ行として返る → 正しく IGNORED 判定）。
+（注: 現行 fixture が行使するのは実リポジトリと同じ階段状 idiom（`!ws`/`ws/*`/… で親を完全除外しない）。
+`dir/` + `!dir/child`（親完全除外 + 無効 `!`）の素朴形は現 fixture では未行使だが、実機検証では
+この形でも効いている除外ルールがマッチ行に返り正しく IGNORED 判定された。）
 
 ### ⚠️ ディレクトリのみパターン × 不在パスの罠（実機検証で判明・要対処）
 
@@ -134,7 +137,7 @@ git は「親ディレクトリが除外されていれば配下の `!` 再 incl
     （`^[^:]*:\d+:`）を strip して `pattern` を得る。`pattern` が `!` 始まりなら false、それ以外 true。
   - ⚠️ `sed 's/.*://'` のような末尾貪欲マッチは `:` を含むパターンで壊れるため使わない。
     必ず TAB 先割り → 行頭 `source:line:` のみ除去。
-- `evaluate(expectations, results)` → `[{path, kind, expected, actual, message}]`
+- `evaluate(expectations, results)` → `[{path, kind, message}]`
   - `results` は `path → check_ignore_output(String)` の Hash（実行スクリプトが収集）
   - `kind == :keep` かつ `ignored?` が true → violation（#31 シナリオ）
   - `kind == :ignore` かつ `ignored?` が false → violation（#9 シナリオ）
@@ -170,8 +173,12 @@ git は「親ディレクトリが除外されていれば配下の `!` 再 incl
 ```makefile
 gitignore-check:
 	@echo "Running gitignore-doctor..."
+	@ruby bin/test_gitignore_doctor.rb
 	@ruby bin/gitignore-doctor.rb
 ```
+
+（本体スクリプト前に unit test を走らせるのは sibling の `precheck` target の house-style に倣ったもの。
+`make gitignore-check` 単体で「ロジックのテスト → 実 .gitignore の検査」が両方走る。）
 
 - **`make tests` には入れない**（最初は手動）。fixture と実態のていれで誤検出 → 無関係な
   tests 赤、を避ける。実績を見てから `precheck` への昇格を検討する。

--- a/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
+++ b/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
@@ -1,0 +1,168 @@
+# gitignore-doctor 設計 (Issue #11)
+
+- **Issue**: #11 「Claude Code スキル化候補: gitignore-doctor（ignore パターン検証）」
+- **作成日**: 2026-06-01
+- **ブランチ**: `feature/11-gitignore-doctor`
+
+## 目的
+
+`.gitignore` の **意図（keep したい / ignore したいパス）と git の実挙動のズレ**を
+機械的に検出する。次の両方向の事故を再発防止する:
+
+- **Issue #9 型**: アンカー漏れ。`plans/`（スラッシュ無し＝任意深度マッチ）を足したら
+  `docs/superpowers/plans/` まで巻き込んだ。本来 commit したいファイルが silently ignore される。
+- **Issue #31 型**: 逆方向。`*.xcworkspace` ワイルドカードが
+  `LeafTimer.xcworkspace/.../Package.resolved` を巻き込み、Xcode Cloud の依存解決が失敗した。
+  whitelist (`!`) が効いているかを毎回手で確認するのは漏れる。
+
+## スコープと前提（重要な設計判断）
+
+Issue 素案には、このリポジトリの確立済みの学びと**衝突する前提が2つ**あったため、
+ブレストで明示的に上書きした:
+
+1. **配置**: Issue 素案は `~/.claude/skills/` への doc スキル新設を想定。
+   → CLAUDE.md の学び「機械的かつプロジェクト固有なチェックは doc スキルではなく
+   **repo スクリプト + make ターゲット**にすべき」に従い、repo 内スクリプトとして実装する。
+   （`writing-skills` のガイダンス: 機械的チェックは自動化・固有規約はリポジトリに置く）
+
+2. **判定コマンド**: Issue 素案は `git check-ignore -v` を想定。
+   → MEMORY `feedback-gitignore-check-ignore-semantics`（実機検証済み）に従い **使わない**。
+   `git check-ignore -v` は「最後にマッチしたルール」を返すコマンドで、それが `!`（再 include）
+   であっても **exit 0** を返すため、whitelist が効いているかの oracle にならない。
+   代わりに `git status --ignored` の出力セクション（Ignored / Untracked）と `git ls-files` で判定する。
+
+## アーキテクチャ
+
+既存の `xcode-precheck` と同じ **2層 + テスト**構造に揃える（命名規約も踏襲）。
+
+| ファイル | 役割 | テスト |
+|---|---|---|
+| `app/bin/gitignore_doctor.rb` | **純粋関数モジュール** `GitignoreDoctor`。fixture パース・git 出力パース・判定。I/O なし | ✅ minitest |
+| `app/bin/gitignore-doctor.rb` | **実行スクリプト**。fixture 読込 → `git` 実行 → モジュールに渡す → 結果表示・exit code | 実行で確認 |
+| `app/bin/gitignore-doctor-expectations.txt` | **期待 fixture**。`keep:` / `ignore:` 行 + `#` コメント | — |
+| `app/bin/test_gitignore_doctor.rb` | 純粋関数の minitest | ✅ |
+
+> **命名規約**: 純粋ロジックは `gitignore_doctor.rb`（アンダースコア）、実行は
+> `gitignore-doctor.rb`（ハイフン）。既存の `xcode_precheck.rb` / `xcode-precheck.rb`
+> と全く同じ命名規約。実行スクリプトが `require_relative 'gitignore_doctor'` する。
+
+- 言語: **Ruby**（標準ライブラリのみ・gem 不要）。`xcode-precheck.rb` と同言語・同パターン。
+- 純粋関数を I/O から分離することで、`git` を実行せずに判定ロジックを全部テストできる
+  （xcode-precheck が `simctl` 出力をテキスト fixture でテストしているのと同じ流儀）。
+
+## データフロー
+
+```
+expectations.txt        git の真実
+  keep:  PATH    ──┐    ┌── `git status --ignored --porcelain` (ignore されているか)
+  ignore: PATH   ──┼──→ ┤
+                   │    └── `git ls-files <path>` (tracked か)
+                   ▼
+        GitignoreDoctor.evaluate(expectations, git_state)
+                   ▼
+          violations[] → 0件なら exit 0 / 1件以上 exit 1
+```
+
+実行スクリプト側**だけ**が `git` を叩き、パース結果を純粋関数に渡す。
+
+## 判定ロジック（心臓部）
+
+| 宣言 | 期待される状態 | NG（FAIL）条件 | 判定 |
+|---|---|---|---|
+| `keep: PATH` | commit 可能（ignore されていない） | **ignore されている** | `git status --ignored` の Ignored セクション(`!!`)に出たら NG |
+| `ignore: PATH` | ignore される | **ignore されていない** | tracked、または Untracked(`??`)で見えていたら NG |
+
+### `keep:` で物理ファイルが存在しない場合
+
+- **警告のみ・FAIL しない**（exit code に影響させない）。
+- 理由: ファイルが単に削除/未生成なだけの可能性があり、それを CI failure にすると
+  「ファイルを消したら gitignore-check が落ちる」という無関係な赤を生む。
+- `ignore:` 側は物理ファイル不要（gitignore はパターンなので、存在しないパスでも
+  「ignore 対象であること」自体は検証意味があるが、判定は status 出力に依存するため
+  実務上は「存在しなければ Untracked にも Ignored にも出ない＝NG にしない」扱い）。
+
+## コンポーネント境界（純粋関数 `GitignoreDoctor`）
+
+すべて I/O なし。
+
+- `parse_expectations(text)` → `[{kind: :keep|:ignore, path: String}]`
+  - `#` コメント行・空行スキップ（xcode-precheck の baseline パース流用）
+  - 行形式: `keep: <path>` / `ignore: <path>`（コロン後の空白は寛容に trim）
+- `parse_git_status(porcelain_text)` → `{ignored: Set<String>, untracked: Set<String>}`
+  - `git status --ignored --porcelain` の `!!` プレフィックス → ignored、`??` → untracked
+  - ディレクトリは末尾 `/` を含む形で出ることがあるため、パス正規化を1箇所に集約
+- `evaluate(expectations, git_state, tracked_paths:)` → `[{path, kind, expected, actual, message}]`
+  - keep が ignored に含まれる → violation（#31 シナリオ）
+  - ignore が tracked または untracked に含まれる → violation（#9 シナリオ）
+
+## エラーハンドリング & エッジケース
+
+- **fixture が存在しない**: スキップ（⚠️ 表示）して exit 0。導入直後に空でも壊れない。
+- **fixture が空**: 「期待0件」で exit 0（xcode-precheck baseline 空の現状と同じ哲学）。
+- **`keep:` の物理ファイル無し**: 警告のみ、FAIL しない（上述）。
+- **git コマンド失敗**: stderr 表示して exit 1。
+- **パス正規化**: 末尾スラッシュ・先頭 `./` のゆれを `evaluate` 前に吸収。
+
+## テスト戦略（TDD）
+
+`test_gitignore_doctor.rb` で純粋関数を minitest 検証。最低限:
+
+1. `parse_expectations`: `keep:`/`ignore:` 行分類、`#` コメント・空行スキップ
+2. `parse_git_status`: `!!path`（ignored）と `??path`（untracked）の分類
+3. `evaluate` — keep が ignore されてたら violation（#31 シナリオ）
+4. `evaluate` — ignore したいのに untracked で見えてたら violation（#9 シナリオ）
+5. `evaluate` — 全て期待どおりなら violations 空
+6. パス正規化（末尾 `/`・先頭 `./` のゆれ）
+
+実装は **TDD**: テストを先に書き、red → green の順で進める。
+
+## 配線
+
+`app/Makefile` に独立ターゲットを追加:
+
+```makefile
+gitignore-check:
+	@echo "Running gitignore-doctor..."
+	@ruby bin/gitignore-doctor.rb
+```
+
+- **`make tests` には入れない**（最初は手動）。fixture と実態のていれで誤検出 → 無関係な
+  tests 赤、を避ける。実績を見てから `precheck` への昇格を検討する。
+- 実行タイミング: `.gitignore` / `expectations.txt` を編集した時に手動で回す。
+
+## 初期 fixture（expectations.txt）
+
+このリポジトリの既知の意図を初期値として明記する（事故の再発検出になる）:
+
+```
+# gitignore-doctor expectations — declares intended keep/ignore paths.
+# `keep:`   = must be committable (NOT ignored). Catches #31-type accidents.
+# `ignore:` = must be ignored. Catches #9-type anchor-leak accidents.
+# Lines starting with # and blank lines are skipped.
+
+# --- #31: Package.resolved must survive the *.xcworkspace wildcard ---
+keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+# --- #9: plan dirs must be anchored so docs/.../plans is not swallowed ---
+keep:   docs/superpowers/plans
+
+# --- things that genuinely must stay ignored ---
+ignore: app/Pods
+ignore: /plans
+```
+
+（初期 fixture の具体的な行は実装時にリポジトリ実態と突き合わせて最終確定する。）
+
+## スコープ外（YAGNI）
+
+- ❌ `.gitignore` 編集の差分トリガー（make 同梱と相性が悪い）
+- ❌ pre-commit hook（`.git/hooks` は git 管理外で共有困難）
+- ❌ パターンの静的 lint（アンカー漏れ regex 検出）— 誤検出が多く、意図アサーション方式が上位互換
+- ❌ 横断スキル化（CLAUDE.md の学びに従い repo に閉じる）
+
+## 関連
+
+- Issue #9（アンカー漏れの原体験、コミット 9862e96 → da32d01 の手戻り）
+- Issue #31（Package.resolved が `*.xcworkspace` に巻き込まれた事故）
+- MEMORY `feedback-gitignore-check-ignore-semantics`（check-ignore を使わない理由の実機検証）
+- 既存実装パターン: `app/bin/xcode-precheck.rb` / `xcode_precheck.rb` / `test_xcode_precheck.rb`

--- a/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
+++ b/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
@@ -25,11 +25,18 @@ Issue 素案には、このリポジトリの確立済みの学びと**衝突す
    **repo スクリプト + make ターゲット**にすべき」に従い、repo 内スクリプトとして実装する。
    （`writing-skills` のガイダンス: 機械的チェックは自動化・固有規約はリポジトリに置く）
 
-2. **判定コマンド**: Issue 素案は `git check-ignore -v` を想定。
-   → MEMORY `feedback-gitignore-check-ignore-semantics`（実機検証済み）に従い **使わない**。
-   `git check-ignore -v` は「最後にマッチしたルール」を返すコマンドで、それが `!`（再 include）
-   であっても **exit 0** を返すため、whitelist が効いているかの oracle にならない。
-   代わりに `git status --ignored` の出力セクション（Ignored / Untracked）と `git ls-files` で判定する。
+2. **判定コマンド**: `git check-ignore --no-index -v <path>` の **出力（マッチしたルール行）**で判定する。
+   MEMORY `feedback-gitignore-check-ignore-semantics` の教訓は「`git check-ignore` の **exit code** を
+   信じるな（`!` 再 include でも exit 0 を返す）」であり、**出力のパースまでは否定していない**。
+   本設計は exit code を一切使わず、出力のマッチルールが `!`（negation）で始まるかで判定するため、
+   この教訓と矛盾しない（実機検証で確認済み・後述）。
+
+   `git status --ignored` を**使わない**理由（実機検証で判明したブロッカー）:
+   `git status --ignored` は **untracked パスしか `!!` で出さない**。tracked なファイルは .gitignore
+   ルールに関係なく tracked のまま残り、`!!` に出ない。よって `keep:` を tracked ファイル
+   （例: 既に commit 済みの `Package.resolved`）に設定すると、whitelist を壊しても status は
+   緑のまま（vacuously green）で **#31 型の回帰を検出できない**。`check-ignore --no-index` は
+   tracked/untracked・ディスク存在に依存せず .gitignore ルール自体を評価するためこの盲点がない。
 
 ## アーキテクチャ
 
@@ -53,33 +60,48 @@ Issue 素案には、このリポジトリの確立済みの学びと**衝突す
 ## データフロー
 
 ```
-expectations.txt        git の真実
-  keep:  PATH    ──┐    ┌── `git status --ignored --porcelain` (ignore されているか)
-  ignore: PATH   ──┼──→ ┤
-                   │    └── `git ls-files <path>` (tracked か)
-                   ▼
-        GitignoreDoctor.evaluate(expectations, git_state)
+expectations.txt              per-path に git へ問い合わせ
+  keep:  PATH    ──┐
+  ignore: PATH   ──┼──→ 各 PATH について実行:
+                   │      `git check-ignore --no-index -v -- <PATH>`
+                   │            │
+                   │            ▼ (出力 = 0 or 1 行: "source:line:pattern\t<PATH>")
+                   ▼      GitignoreDoctor.ignored?(check_ignore_output)
+        GitignoreDoctor.evaluate(expectations, per_path_results)
                    ▼
           violations[] → 0件なら exit 0 / 1件以上 exit 1
 ```
 
-実行スクリプト側**だけ**が `git` を叩き、パース結果を純粋関数に渡す。
+実行スクリプト側**だけ**が `git` を **リポジトリルートで** path ごとに叩き、その生出力を
+純粋関数に渡す。`check-ignore` に渡す `<PATH>` は fixture 記載の**リポジトリルート相対**パス。
+
+## オラクル: `git check-ignore --no-index -v`（実機検証済み）
+
+判定は exit code を使わず、**マッチしたルール行**を見る。
+
+- 出力が**空** → どのルールにもマッチしない → **NOT ignored**
+- 出力あり（`source:line:pattern\t<path>`）でマッチ `pattern` が `!` 始まり → **NOT ignored**（有効な negation）
+- 出力ありでマッチ `pattern` が `!` 以外 → **IGNORED**
+
+`--no-index` は tracked/untracked・ディスク存在に依存せず .gitignore ルールを評価する。
+git は「親ディレクトリが除外されていれば配下の `!` 再 include は無効」というルールも
+**評価済みの最終結果**としてマッチ行に反映する（実機確認: 階段状 whitelist を `ws/` 一発に
+簡略化すると、`!…Package.resolved` ではなく効いている `ws/` がマッチ行として返る → 正しく IGNORED 判定）。
+ディレクトリパス（末尾スラッシュ有無どちらでも）も正しくマッチする（実機確認済み）。
 
 ## 判定ロジック（心臓部）
 
 | 宣言 | 期待される状態 | NG（FAIL）条件 | 判定 |
 |---|---|---|---|
-| `keep: PATH` | commit 可能（ignore されていない） | **ignore されている** | `git status --ignored` の Ignored セクション(`!!`)に出たら NG |
-| `ignore: PATH` | ignore される | **ignore されていない** | tracked、または Untracked(`??`)で見えていたら NG |
+| `keep: PATH` | ignore されない（commit 可能） | **ignored** | `ignored?(output)` が true なら violation（#31 型） |
+| `ignore: PATH` | ignore される | **NOT ignored** | `ignored?(output)` が false なら violation（#9 型） |
 
 ### `keep:` で物理ファイルが存在しない場合
 
-- **警告のみ・FAIL しない**（exit code に影響させない）。
-- 理由: ファイルが単に削除/未生成なだけの可能性があり、それを CI failure にすると
-  「ファイルを消したら gitignore-check が落ちる」という無関係な赤を生む。
-- `ignore:` 側は物理ファイル不要（gitignore はパターンなので、存在しないパスでも
-  「ignore 対象であること」自体は検証意味があるが、判定は status 出力に依存するため
-  実務上は「存在しなければ Untracked にも Ignored にも出ない＝NG にしない」扱い）。
+- **判定に影響しない**（物理存在チェックはしない）。
+- 理由: `--no-index` はディスク上のファイル有無と無関係に .gitignore パターンを評価するため、
+  「ファイルが消えている → status に出ない → 緑」という旧 status 方式の盲点が**そもそも無い**。
+  パターンとしての ignore 判定は物理ファイルなしでも成立する。
 
 ## コンポーネント境界（純粋関数 `GitignoreDoctor`）
 
@@ -88,31 +110,39 @@ expectations.txt        git の真実
 - `parse_expectations(text)` → `[{kind: :keep|:ignore, path: String}]`
   - `#` コメント行・空行スキップ（xcode-precheck の baseline パース流用）
   - 行形式: `keep: <path>` / `ignore: <path>`（コロン後の空白は寛容に trim）
-- `parse_git_status(porcelain_text)` → `{ignored: Set<String>, untracked: Set<String>}`
-  - `git status --ignored --porcelain` の `!!` プレフィックス → ignored、`??` → untracked
-  - ディレクトリは末尾 `/` を含む形で出ることがあるため、パス正規化を1箇所に集約
-- `evaluate(expectations, git_state, tracked_paths:)` → `[{path, kind, expected, actual, message}]`
-  - keep が ignored に含まれる → violation（#31 シナリオ）
-  - ignore が tracked または untracked に含まれる → violation（#9 シナリオ）
+- `ignored?(check_ignore_output)` → `Boolean`
+  - 入力は `git check-ignore --no-index -v -- <path>` の生出力（0 or 1 行の String）
+  - 空文字列 → false
+  - 1 行ある場合: **TAB で先割り**して左辺 `source:line:pattern` を取り、先頭の `source:line:`
+    （`^[^:]*:\d+:`）を strip して `pattern` を得る。`pattern` が `!` 始まりなら false、それ以外 true。
+  - ⚠️ `sed 's/.*://'` のような末尾貪欲マッチは `:` を含むパターンで壊れるため使わない。
+    必ず TAB 先割り → 行頭 `source:line:` のみ除去。
+- `evaluate(expectations, results)` → `[{path, kind, expected, actual, message}]`
+  - `results` は `path → check_ignore_output(String)` の Hash（実行スクリプトが収集）
+  - `kind == :keep` かつ `ignored?` が true → violation（#31 シナリオ）
+  - `kind == :ignore` かつ `ignored?` が false → violation（#9 シナリオ）
 
 ## エラーハンドリング & エッジケース
 
 - **fixture が存在しない**: スキップ（⚠️ 表示）して exit 0。導入直後に空でも壊れない。
 - **fixture が空**: 「期待0件」で exit 0（xcode-precheck baseline 空の現状と同じ哲学）。
-- **`keep:` の物理ファイル無し**: 警告のみ、FAIL しない（上述）。
-- **git コマンド失敗**: stderr 表示して exit 1。
-- **パス正規化**: 末尾スラッシュ・先頭 `./` のゆれを `evaluate` 前に吸収。
+- **`keep:` の物理ファイル無し**: 判定に影響しない（上述）。
+- **git コマンド失敗**（リポジトリ外など）: stderr 表示して exit 1。
+- **パス正規化**: fixture は repo ルート相対で書く。`check-ignore` は `--no-index` なので
+  ディスク存在に依存しないが、末尾 `/`・先頭 `./` のゆれは `parse_expectations` で吸収。
 
 ## テスト戦略（TDD）
 
-`test_gitignore_doctor.rb` で純粋関数を minitest 検証。最低限:
+`test_gitignore_doctor.rb` で純粋関数を minitest 検証（git 実行なし・出力テキストを fixture 化）。最低限:
 
-1. `parse_expectations`: `keep:`/`ignore:` 行分類、`#` コメント・空行スキップ
-2. `parse_git_status`: `!!path`（ignored）と `??path`（untracked）の分類
-3. `evaluate` — keep が ignore されてたら violation（#31 シナリオ）
-4. `evaluate` — ignore したいのに untracked で見えてたら violation（#9 シナリオ）
-5. `evaluate` — 全て期待どおりなら violations 空
-6. パス正規化（末尾 `/`・先頭 `./` のゆれ）
+1. `parse_expectations`: `keep:`/`ignore:` 行分類、`#` コメント・空行スキップ、末尾 `/`・先頭 `./` 吸収
+2. `ignored?`: 空出力 → false
+3. `ignored?`: `!` 始まりルール行 → false（有効 negation）
+4. `ignored?`: 通常ルール行 → true
+5. `ignored?`: パターンに `:` を含む行でも TAB 先割りで正しく抽出（脆い末尾マッチ回帰防止）
+6. `evaluate` — keep が ignored なら violation（#31 シナリオ）
+7. `evaluate` — ignore が NOT ignored なら violation（#9 シナリオ）
+8. `evaluate` — 全て期待どおりなら violations 空
 
 実装は **TDD**: テストを先に書き、red → green の順で進める。
 
@@ -148,10 +178,15 @@ keep:   docs/superpowers/plans
 
 # --- things that genuinely must stay ignored ---
 ignore: app/Pods
-ignore: /plans
+ignore: plans
 ```
 
-（初期 fixture の具体的な行は実装時にリポジトリ実態と突き合わせて最終確定する。）
+- fixture のパスは **repo ルート相対**で書く（先頭スラッシュ無し）。`git check-ignore` に
+  渡す引数の `/plans` は「絶対パス」と解釈されうるため、ルート相対の `plans` と書く。
+  これは `.gitignore` 側の `/plans`（アンカー）とは別概念（fixture = 検査対象パス、
+  `.gitignore` = ルール）。
+- （初期 fixture の具体的な行は実装時にリポジトリ実態と突き合わせ、`make gitignore-check` が
+  green になることを確認して最終確定する。）
 
 ## スコープ外（YAGNI）
 
@@ -164,5 +199,6 @@ ignore: /plans
 
 - Issue #9（アンカー漏れの原体験、コミット 9862e96 → da32d01 の手戻り）
 - Issue #31（Package.resolved が `*.xcworkspace` に巻き込まれた事故）
-- MEMORY `feedback-gitignore-check-ignore-semantics`（check-ignore を使わない理由の実機検証）
+- MEMORY `feedback-gitignore-check-ignore-semantics`（**exit code** は信じない／`-v` 出力の
+  last-rule パースは有効、という制約の実機検証。本 issue 着手時に更新する）
 - 既存実装パターン: `app/bin/xcode-precheck.rb` / `xcode_precheck.rb` / `test_xcode_precheck.rb`

--- a/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
+++ b/docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md
@@ -83,11 +83,24 @@ expectations.txt              per-path に git へ問い合わせ
 - 出力あり（`source:line:pattern\t<path>`）でマッチ `pattern` が `!` 始まり → **NOT ignored**（有効な negation）
 - 出力ありでマッチ `pattern` が `!` 以外 → **IGNORED**
 
-`--no-index` は tracked/untracked・ディスク存在に依存せず .gitignore ルールを評価する。
+`--no-index` は tracked/untracked に依存せず .gitignore ルールを評価する。
 git は「親ディレクトリが除外されていれば配下の `!` 再 include は無効」というルールも
 **評価済みの最終結果**としてマッチ行に反映する（実機確認: 階段状 whitelist を `ws/` 一発に
 簡略化すると、`!…Package.resolved` ではなく効いている `ws/` がマッチ行として返る → 正しく IGNORED 判定）。
-ディレクトリパス（末尾スラッシュ有無どちらでも）も正しくマッチする（実機確認済み）。
+
+### ⚠️ ディレクトリのみパターン × 不在パスの罠（実機検証で判明・要対処）
+
+`--no-index` は**ファイルパターンにはディスク非依存**だが、**`Pods/` のような末尾スラッシュ付き
+（ディレクトリのみ）パターンは working tree の stat に依存する**。検査対象パスを
+スラッシュ無し（`app/Pods`）で渡し、かつそのパスが**ディスク上に存在しない**（fresh clone や
+`make install` 前で `Pods/` が無い等）と、ディレクトリと認識されず **マッチせず → "NOT ignored"** を
+返す。これは `ignore:` 宣言で **false violation（環境依存の偽 RED）** を生む。
+
+**対処**: fixture では**ディレクトリ意図のパスに末尾スラッシュを明記**する（`ignore: app/Pods/`）。
+末尾スラッシュ付きで渡すと、対象が**不在でもディレクトリパターンに安定してマッチ**する（実機確認:
+`Pods/` ルールに対し `-- Pods/` は absent/present どちらでも matched、`-- Pods` は absent で no-match）。
+したがって `parse_expectations` は**末尾スラッシュを吸収せず保持**する（dir 意図のシグナル）。
+ファイル意図のパス（`...Package.resolved`）はスラッシュ無しで書く。
 
 ## 判定ロジック（心臓部）
 
@@ -96,12 +109,14 @@ git は「親ディレクトリが除外されていれば配下の `!` 再 incl
 | `keep: PATH` | ignore されない（commit 可能） | **ignored** | `ignored?(output)` が true なら violation（#31 型） |
 | `ignore: PATH` | ignore される | **NOT ignored** | `ignored?(output)` が false なら violation（#9 型） |
 
-### `keep:` で物理ファイルが存在しない場合
+### 物理ファイルの存在について
 
-- **判定に影響しない**（物理存在チェックはしない）。
-- 理由: `--no-index` はディスク上のファイル有無と無関係に .gitignore パターンを評価するため、
-  「ファイルが消えている → status に出ない → 緑」という旧 status 方式の盲点が**そもそも無い**。
-  パターンとしての ignore 判定は物理ファイルなしでも成立する。
+- **ファイル意図のパス（スラッシュ無し）**: `--no-index` はディスク上のファイル有無と無関係に
+  .gitignore のファイルパターンを評価するため、物理存在チェックは不要。
+  旧 status 方式の「ファイルが消えている → status に出ない → 緑」という盲点が**そもそも無い**。
+- **ディレクトリ意図のパス（末尾スラッシュ付き）**: 上記の罠どおり、不在時にスラッシュ無しだと
+  誤判定するため、必ず**末尾スラッシュを付けて**安定マッチさせる。スラッシュ付きなら不在でも
+  ディレクトリパターンに正しくマッチする。
 
 ## コンポーネント境界（純粋関数 `GitignoreDoctor`）
 
@@ -110,6 +125,8 @@ git は「親ディレクトリが除外されていれば配下の `!` 再 incl
 - `parse_expectations(text)` → `[{kind: :keep|:ignore, path: String}]`
   - `#` コメント行・空行スキップ（xcode-precheck の baseline パース流用）
   - 行形式: `keep: <path>` / `ignore: <path>`（コロン後の空白は寛容に trim）
+  - 先頭 `./` は吸収するが、**末尾 `/` は保持**する（ディレクトリ意図のシグナルとして
+    check-ignore にそのまま渡し、不在ディレクトリの誤判定を防ぐ。上記の罠を参照）
 - `ignored?(check_ignore_output)` → `Boolean`
   - 入力は `git check-ignore --no-index -v -- <path>` の生出力（0 or 1 行の String）
   - 空文字列 → false
@@ -170,21 +187,23 @@ gitignore-check:
 # `ignore:` = must be ignored. Catches #9-type anchor-leak accidents.
 # Lines starting with # and blank lines are skipped.
 
-# --- #31: Package.resolved must survive the *.xcworkspace wildcard ---
+# --- #31: Package.resolved must survive the *.xcworkspace ignore ladder (FILE) ---
 keep:   app/LeafTimer.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
-# --- #9: plan dirs must be anchored so docs/.../plans is not swallowed ---
-keep:   docs/superpowers/plans
+# --- #9: plan docs must NOT be swallowed by an unanchored 'plans' (DIR) ---
+keep:   docs/superpowers/plans/
 
-# --- things that genuinely must stay ignored ---
-ignore: app/Pods
-ignore: plans
+# --- paths that genuinely must stay ignored (DIRs → trailing slash) ---
+ignore: app/Pods/
+ignore: plans/
 ```
 
 - fixture のパスは **repo ルート相対**で書く（先頭スラッシュ無し）。`git check-ignore` に
-  渡す引数の `/plans` は「絶対パス」と解釈されうるため、ルート相対の `plans` と書く。
+  渡す引数の `/plans` は「絶対パス」と解釈されうるため、ルート相対の `plans/` と書く。
   これは `.gitignore` 側の `/plans`（アンカー）とは別概念（fixture = 検査対象パス、
   `.gitignore` = ルール）。
+- **ディレクトリ意図のパスは末尾スラッシュを付ける**（`app/Pods/` `plans/` `docs/.../plans/`）。
+  不在ディレクトリでの誤判定を防ぐため（上記の罠）。ファイル意図はスラッシュ無し。
 - （初期 fixture の具体的な行は実装時にリポジトリ実態と突き合わせ、`make gitignore-check` が
   green になることを確認して最終確定する。）
 


### PR DESCRIPTION
## Summary

`.gitignore` の **意図（keep/ignore したいパス）と git の実挙動のズレ**を `make gitignore-check` で機械検出する repo スクリプトを追加。過去の両方向の事故を再発防止する:

- **#9 型**: アンカー漏れ（`plans/` が `docs/superpowers/plans/` を巻き込む）
- **#31 型**: whitelist 漏れ（`*.xcworkspace` が `Package.resolved` を巻き込む）

既存の `xcode-precheck` と同じ **2層 + minitest** 構造（純粋関数 `gitignore_doctor.rb` + 実行 `gitignore-doctor.rb` + fixture + テスト）。

## 設計上の重要な判断

- **オラクルは `git check-ignore --no-index -v` の出力パース**（exit code は使わない）。`!` negation でも exit 0 を返すため exit code は信頼できない、という MEMORY の教訓を遵守しつつ、出力のマッチルール行を `!` 始まりか否かで判定。
- `git status --ignored` は **tracked ファイルに盲目**（vacuously green で #31 を見逃す）ため不採用。実機検証で確定。
- **ディレクトリ意図のパスは fixture で末尾スラッシュ必須**（`app/Pods/`）。スラッシュ無し + 不在パスだと false-negative になる罠を実機検証で発見し回避。fresh clone（`app/Pods/` / `plans/` 不在）でも安定判定。
- fixture の malformed 行（`keep:` タイポ等）は **silent drop せず ParseError で hard fail**。「守ってるつもりで守れてない」事故を防ぐ。
- `make tests` には**入れない**独立 target（最初は手動運用、実績を見て昇格判断）。`.swift`/`.pbxproj` は不変（repo スクリプトのみ）。

## Test Plan

- [x] `cd app && ruby bin/test_gitignore_doctor.rb` → 13 runs, 0 failures
- [x] `cd app && make gitignore-check` → unit test 後に `✅ 4 expectation(s) satisfied`
- [x] RED 確認: keep が ignored / ignore が not-ignored / malformed 行 の3方向で exit 1 になることを実機検証
- [x] 3段階レビュー: spec compliance ✅ / code quality 🔧→fixed / final ✅

## 備考（レビュー指摘の transparency）

- 現 fixture が行使するのは実リポと同じ階段状 whitelist idiom。`dir/` + 無効 `!dir/child` の素朴形は fixture では未行使（ただし実機検証ではこの形でも正しく IGNORED 判定された）。

設計: \`docs/superpowers/specs/2026-06-01-gitignore-doctor-design.md\`
計画: \`docs/superpowers/plans/2026-06-01-issue-11-gitignore-doctor.md\`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)