### PR TITLE
feat(ads): #57 AdMob の GDPR 同意 (UMP) と ATT を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
 
 ### 効率化ルール
 
-- 並列 teammate agent を dispatch する時は、指示書に「完了したら idle になる前に最終報告の全文を SendMessage で main へ送信する」を必ず明記する。Why: idle 通知だけでは報告本文が main に届かず、5体中4体へ「報告を送って」という回収往復 (SendMessage) が余分に発生した実績がある。How to apply: 並列 agent の指示書テンプレの末尾に「最終報告を SendMessage で送ってから終了」を定型文として入れる。
+- **全ての** agent dispatch (並列 teammate に限らず、implementer / reviewer / fixer など単発 subagent も含む) の指示書に「最終報告の全文を SendMessage で main へ送信してから idle になる」を必ず明記する。Why: idle 通知だけでは報告本文が main に届かず回収往復が発生する。並列 5体中4体で発生した初回実績に加え、Issue #57 では SDD の task reviewer dispatch でこの定型文を入れ忘れて再発した (implementer 向けと思い込み、reviewer には不要と暗黙に判断したのが敗因)。How to apply: skill のテンプレ (subagent-driven-development の implementer/reviewer/fixer prompt 等) を使う時も、テンプレに定型文が無ければ dispatch 前に必ず末尾へ追記する。役割を問わず「dispatch = 定型文チェック」を機械的に行う。
 - 新規 hook スクリプト（SessionEnd/SessionStart など）を settings.json に配線する前に、sample JSON を stdin に pipe-test して bail 条件・self-detach・sentinel ガードを単体検証する。配線後の silent failure（特に `claude -p --bare` の OAuth 切れのような沈黙失敗）を未然に検出できる。
 - plan-driven な PR では、Issue #15 の `f2df20e` の convention に倣い、**実装の最初のコミットとして** `docs/superpowers/plans/<date>-<feature>.md` を含める。PR 作成後の追い commit になると CI 履歴とレビュー導線がズレるため、ブランチ作成直後に plan を commit する。
 - ブランチ push や `gh pr create` の前に、必ず `git fetch && gh pr list --state all --head <branch>` で既存 PR / merge 状況を確認する。ローカル master が古いまま push して「既に MERGED」で空振りするのを防ぐ。

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		27AC7EA43074765A7875051B /* KeyManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F499F2971862F940DBB1C9A1 /* KeyManagerSpec.swift */; };
 		2E2CB3CE983BECF622864400 /* Pods_LeafTimer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17C7491631569CCC5150105 /* Pods_LeafTimer.framework */; };
 		2FB91AC254201D5F19E31B12 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7357CD442DB907774538B896 /* HistoryViewModel.swift */; };
+		363E8C15E0B07F563138BE48 /* AdsConsentServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778C7E3BFF5D30AEC8A30D91 /* AdsConsentServices.swift */; };
 		3818BC6424E38E5E0070C612 /* LocalUserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3818BC6324E38E5E0070C612 /* LocalUserDefaultWrapper.swift */; };
 		3818BC6624E3902F0070C612 /* TimerViewModel+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3818BC6524E3902F0070C612 /* TimerViewModel+extensions.swift */; };
 		3818BC6924E392B60070C612 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3818BC6824E392B60070C612 /* SettingViewModel.swift */; };
@@ -161,6 +162,7 @@
 		6F34D2A812A6B1BF5AE66D6A /* EnhancedSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedSettingView.swift; sourceTree = "<group>"; };
 		70A6985F541ACE9813FDE40C /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoryViewModelTests.swift; path = LeafTimerTests/HistoryViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		7357CD442DB907774538B896 /* HistoryViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoryViewModel.swift; path = LeafTimer/ViewModel/HistoryViewModel.swift; sourceTree = SOURCE_ROOT; };
+		778C7E3BFF5D30AEC8A30D91 /* AdsConsentServices.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdsConsentServices.swift; path = LeafTimer/Components/AdsConsentServices.swift; sourceTree = SOURCE_ROOT; };
 		7DAD93010F495D56669DB0F5 /* OnboardingLocalizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OnboardingLocalizationTests.swift; path = LeafTimerTests/OnboardingLocalizationTests.swift; sourceTree = SOURCE_ROOT; };
 		7FBD5086205B41F0F0930480 /* OnboardingGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OnboardingGateTests.swift; path = LeafTimerTests/OnboardingGateTests.swift; sourceTree = SOURCE_ROOT; };
 		8653E98698211081B54C46C8 /* Pods_LeafTimer_LeafTimerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeafTimer_LeafTimerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -246,6 +248,7 @@
 				FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */,
 				3818BC6C24EA4DA10070C612 /* UserDefaultItem.swift */,
 				99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */,
+				778C7E3BFF5D30AEC8A30D91 /* AdsConsentServices.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -767,6 +770,7 @@
 				3856FB8324AC19F7007F40E5 /* TimerViewModel.swift in Sources */,
 				3818BC6D24EA4DA10070C612 /* UserDefaultItem.swift in Sources */,
 				FC0EFE04C6A0827F8110890E /* AdsBootstrapper.swift in Sources */,
+				363E8C15E0B07F563138BE48 /* AdsConsentServices.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -236,6 +236,8 @@
 		3856FB7B24A8C3AB007F40E5 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */,
+				778C7E3BFF5D30AEC8A30D91 /* AdsConsentServices.swift */,
 				93FFE81324FF1BE500AA1BD1 /* DateManager.swift */,
 				3865AB4624CD26D3001B03E4 /* DefaultAudioManager.swift */,
 				3856FB8424AC1FE0007F40E5 /* DefaultTimerManager.swift */,
@@ -247,8 +249,6 @@
 				0C7BB13FEE55FA28FD1D9045 /* SessionStatsRepository.swift */,
 				FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */,
 				3818BC6C24EA4DA10070C612 /* UserDefaultItem.swift */,
-				99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */,
-				778C7E3BFF5D30AEC8A30D91 /* AdsConsentServices.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -355,6 +355,7 @@
 		3864B7E12494D82300948ACA /* LeafTimerTests */ = {
 			isa = PBXGroup;
 			children = (
+				12FDA2C80A4547BB35C1BBD3 /* AdsBootstrapperTests.swift */,
 				CABE061EA25A9493CEA2D71A /* AudioSystemVerificationTests.swift */,
 				5151B3410F58F7065CC50B28 /* DataPersistenceTests.swift */,
 				70A6985F541ACE9813FDE40C /* HistoryViewModelTests.swift */,
@@ -377,7 +378,6 @@
 				6CD2388AFF3537F36562A156 /* StatLocalizationTests.swift */,
 				367A1939D36F08DBA924500D /* TimerCoreLogicSpec.swift */,
 				3864B7E22494D82300948ACA /* TimerViewSpec.swift */,
-				12FDA2C80A4547BB35C1BBD3 /* AdsBootstrapperTests.swift */,
 			);
 			path = LeafTimerTests;
 			sourceTree = "<group>";
@@ -739,6 +739,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				20AE081601A9F079317B73CF /* AboutSettingsSection.swift in Sources */,
+				FC0EFE04C6A0827F8110890E /* AdsBootstrapper.swift in Sources */,
+				363E8C15E0B07F563138BE48 /* AdsConsentServices.swift in Sources */,
 				38C95EF325D7270D00D80736 /* AdsView.swift in Sources */,
 				3864B7CC2494D81D00948ACA /* AppDelegate.swift in Sources */,
 				3818BC6B24E6D5BB0070C612 /* Binding+extension.swift in Sources */,
@@ -769,8 +771,6 @@
 				3818BC6624E3902F0070C612 /* TimerViewModel+extensions.swift in Sources */,
 				3856FB8324AC19F7007F40E5 /* TimerViewModel.swift in Sources */,
 				3818BC6D24EA4DA10070C612 /* UserDefaultItem.swift in Sources */,
-				FC0EFE04C6A0827F8110890E /* AdsBootstrapper.swift in Sources */,
-				363E8C15E0B07F563138BE48 /* AdsConsentServices.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -778,6 +778,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08FF107914E06D3B1DB6BA0A /* AdsBootstrapperTests.swift in Sources */,
 				963EF4D63578A80E831E1348 /* AudioSystemVerificationTests.swift in Sources */,
 				AA4DC0FF04EDCB116B7E1601 /* DataPersistenceTests.swift in Sources */,
 				CF50496645D51CA09C4F1D85 /* HistoryViewModelTests.swift in Sources */,
@@ -799,7 +800,6 @@
 				805461750A8F83B7A5F713B1 /* StatLocalizationTests.swift in Sources */,
 				669C987E4610024B49B6A047 /* TimerCoreLogicSpec.swift in Sources */,
 				3864B7E32494D82300948ACA /* TimerViewSpec.swift in Sources */,
-				08FF107914E06D3B1DB6BA0A /* AdsBootstrapperTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/LeafTimer.xcodeproj/project.pbxproj
+++ b/app/LeafTimer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08FF107914E06D3B1DB6BA0A /* AdsBootstrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FDA2C80A4547BB35C1BBD3 /* AdsBootstrapperTests.swift */; };
 		1203FF4572F21438D8A79802 /* LocalSessionStatsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E5BFB598B6047A011C144E /* LocalSessionStatsRepository.swift */; };
 		1DA7D67C578599E61615EB0A /* SoundSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67AB20F46B6C8D33B5653CA4 /* SoundSettingsSection.swift */; };
 		20AE081601A9F079317B73CF /* AboutSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE2E351DBFBBEAF8AE6EA6C /* AboutSettingsSection.swift */; };
@@ -78,6 +79,7 @@
 		D5D32D4B2EB811A900DECF70 /* bgm3.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = D5D32D482EB811A900DECF70 /* bgm3.mp3 */; };
 		E5EE5B694F71609B83B26C7E /* ModernTimerViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */; };
 		F2B6E50A848C74D7C919E1B7 /* ResetSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58052409AAA0F0D30423F06C /* ResetSettingsSection.swift */; };
+		FC0EFE04C6A0827F8110890E /* AdsBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,6 +103,7 @@
 		037C5BC22762109945219857 /* Pods-LeafTimerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimerUITests.debug.xcconfig"; path = "Target Support Files/Pods-LeafTimerUITests/Pods-LeafTimerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		051B521F216134FC418A5DB3 /* Pods-LeafTimer-LeafTimerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeafTimer-LeafTimerUITests.release.xcconfig"; path = "Target Support Files/Pods-LeafTimer-LeafTimerUITests/Pods-LeafTimer-LeafTimerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		0C7BB13FEE55FA28FD1D9045 /* SessionStatsRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SessionStatsRepository.swift; path = LeafTimer/Components/SessionStatsRepository.swift; sourceTree = SOURCE_ROOT; };
+		12FDA2C80A4547BB35C1BBD3 /* AdsBootstrapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdsBootstrapperTests.swift; path = LeafTimerTests/AdsBootstrapperTests.swift; sourceTree = SOURCE_ROOT; };
 		158C104A0A1B7740F4ED17C1 /* ModernTimerViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernTimerViewSpec.swift; sourceTree = "<group>"; };
 		1DDE2E67318AACEA8D89EF69 /* Pods_LeafTimerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeafTimerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		23BBF65B0E0977372AEB15F2 /* SessionStatsMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SessionStatsMigrationTests.swift; path = LeafTimerTests/SessionStatsMigrationTests.swift; sourceTree = SOURCE_ROOT; };
@@ -164,6 +167,7 @@
 		93FFE81224FE3E8E00AA1BD1 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		93FFE81324FF1BE500AA1BD1 /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
 		9633C291CA6739AD8BBCAE0C /* TimerSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSettingsSection.swift; sourceTree = "<group>"; };
+		99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdsBootstrapper.swift; path = LeafTimer/Components/AdsBootstrapper.swift; sourceTree = SOURCE_ROOT; };
 		A17C7491631569CCC5150105 /* Pods_LeafTimer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeafTimer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A244D33CACD5F760C129A96C /* HistoryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoryView.swift; path = LeafTimer/View/HistoryView.swift; sourceTree = SOURCE_ROOT; };
 		A5E76F08701A5811DDED6A33 /* ReviewIntegrationSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReviewIntegrationSpec.swift; path = LeafTimerTests/ReviewIntegrationSpec.swift; sourceTree = SOURCE_ROOT; };
@@ -241,6 +245,7 @@
 				0C7BB13FEE55FA28FD1D9045 /* SessionStatsRepository.swift */,
 				FC5BDA9EDBD7184C762F2AD7 /* StoreKitReviewRequester.swift */,
 				3818BC6C24EA4DA10070C612 /* UserDefaultItem.swift */,
+				99A467A0560BAC8023451DDC /* AdsBootstrapper.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -369,6 +374,7 @@
 				6CD2388AFF3537F36562A156 /* StatLocalizationTests.swift */,
 				367A1939D36F08DBA924500D /* TimerCoreLogicSpec.swift */,
 				3864B7E22494D82300948ACA /* TimerViewSpec.swift */,
+				12FDA2C80A4547BB35C1BBD3 /* AdsBootstrapperTests.swift */,
 			);
 			path = LeafTimerTests;
 			sourceTree = "<group>";
@@ -760,6 +766,7 @@
 				3818BC6624E3902F0070C612 /* TimerViewModel+extensions.swift in Sources */,
 				3856FB8324AC19F7007F40E5 /* TimerViewModel.swift in Sources */,
 				3818BC6D24EA4DA10070C612 /* UserDefaultItem.swift in Sources */,
+				FC0EFE04C6A0827F8110890E /* AdsBootstrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -788,6 +795,7 @@
 				805461750A8F83B7A5F713B1 /* StatLocalizationTests.swift in Sources */,
 				669C987E4610024B49B6A047 /* TimerCoreLogicSpec.swift in Sources */,
 				3864B7E32494D82300948ACA /* TimerViewSpec.swift in Sources */,
+				08FF107914E06D3B1DB6BA0A /* AdsBootstrapperTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/LeafTimer/App/AppDelegate.swift
+++ b/app/LeafTimer/App/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         FirebaseApp.configure()
-        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        // GADMobileAds の start は UMP 同意 + ATT 完了後に AdsBootstrapper が行う (#57)
 
         window = UIWindow()
 
@@ -37,6 +37,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window?.rootViewController = vc
         window?.makeKeyAndVisible()
+
+        // 同意フォーム/ATT ダイアログの提示は app active 後である必要があるため
+        // 起動処理完了後の main queue で開始する
+        DispatchQueue.main.async { [weak self] in
+            AdsBootstrapper.shared.bootstrap(
+                from: self?.window?.rootViewController,
+                completion: nil
+            )
+        }
 
         // AVAudioSession の設定は DefaultAudioManager に一元化している (#55)。
         // ここで options 無しの setCategory を呼ぶと .mixWithOthers が上書きされ、

--- a/app/LeafTimer/App/AppDelegate.swift
+++ b/app/LeafTimer/App/AppDelegate.swift
@@ -1,5 +1,4 @@
 import Firebase
-import GoogleMobileAds
 import SwiftUI
 import UIKit
 

--- a/app/LeafTimer/App/en.lproj/InfoPlist.strings
+++ b/app/LeafTimer/App/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 /* InfoPlist.strings (English) */
 "CFBundleDisplayName" = "LeafTimer";
+"NSUserTrackingUsageDescription" = "This identifier will be used to deliver personalized ads to you.";
 

--- a/app/LeafTimer/App/ja.lproj/InfoPlist.strings
+++ b/app/LeafTimer/App/ja.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 /* InfoPlist.strings (Japanese) */
 "CFBundleDisplayName" = "LeafTimer"; /* 好みで「リーフタイマー」に変更可 */
+"NSUserTrackingUsageDescription" = "広告配信を最適化するために識別子を使用します。";
 

--- a/app/LeafTimer/Components/AdsBootstrapper.swift
+++ b/app/LeafTimer/Components/AdsBootstrapper.swift
@@ -27,10 +27,12 @@ final class AdsBootstrapper: ObservableObject {
     private let adsStarter: AdsStarter
     private var isBootstrapping = false
 
+    static let shared = AdsBootstrapper()
+
     init(
-        consentService: ConsentService,
-        trackingAuthorizer: TrackingAuthorizer,
-        adsStarter: AdsStarter
+        consentService: ConsentService = UMPConsentService(),
+        trackingAuthorizer: TrackingAuthorizer = ATTAuthorizer(),
+        adsStarter: AdsStarter = GADAdsStarter()
     ) {
         self.consentService = consentService
         self.trackingAuthorizer = trackingAuthorizer

--- a/app/LeafTimer/Components/AdsBootstrapper.swift
+++ b/app/LeafTimer/Components/AdsBootstrapper.swift
@@ -1,0 +1,61 @@
+import Foundation
+import UIKit
+
+protocol ConsentService {
+    var canRequestAds: Bool { get }
+    func gatherConsent(
+        from viewController: UIViewController?,
+        completion: @escaping (Error?) -> Void
+    )
+}
+
+protocol TrackingAuthorizer {
+    func requestAuthorization(completion: @escaping () -> Void)
+}
+
+protocol AdsStarter {
+    func startAds()
+}
+
+/// 広告表示前の同意フローを統括する。
+/// 順序: UMP 同意取得 → ATT 許可リクエスト → (同意 OK なら) GADMobileAds start
+final class AdsBootstrapper: ObservableObject {
+    @Published private(set) var isAdsStarted = false
+
+    private let consentService: ConsentService
+    private let trackingAuthorizer: TrackingAuthorizer
+    private let adsStarter: AdsStarter
+    private var isBootstrapping = false
+
+    init(
+        consentService: ConsentService,
+        trackingAuthorizer: TrackingAuthorizer,
+        adsStarter: AdsStarter
+    ) {
+        self.consentService = consentService
+        self.trackingAuthorizer = trackingAuthorizer
+        self.adsStarter = adsStarter
+    }
+
+    func bootstrap(from viewController: UIViewController?, completion: (() -> Void)?) {
+        guard !isAdsStarted, !isBootstrapping else {
+            completion?()
+            return
+        }
+        isBootstrapping = true
+
+        // UMP がエラーを返しても前回セッションの cached 同意で
+        // canRequestAds が立ち得るため、エラーでもフローは継続する
+        consentService.gatherConsent(from: viewController) { [weak self] _ in
+            self?.trackingAuthorizer.requestAuthorization {
+                guard let self else { return }
+                self.isBootstrapping = false
+                if self.consentService.canRequestAds {
+                    self.adsStarter.startAds()
+                    self.isAdsStarted = true
+                }
+                completion?()
+            }
+        }
+    }
+}

--- a/app/LeafTimer/Components/AdsConsentServices.swift
+++ b/app/LeafTimer/Components/AdsConsentServices.swift
@@ -1,0 +1,57 @@
+import AppTrackingTransparency
+import GoogleMobileAds
+import UIKit
+import UserMessagingPlatform
+
+/// UMP (User Messaging Platform) による GDPR 同意取得。
+/// EEA/UK 以外の地域では form 提示不要と判定され、そのまま completion が呼ばれる。
+final class UMPConsentService: ConsentService {
+    var canRequestAds: Bool {
+        ConsentInformation.shared.canRequestAds
+    }
+
+    func gatherConsent(
+        from viewController: UIViewController?,
+        completion: @escaping (Error?) -> Void
+    ) {
+        let parameters = RequestParameters()
+        #if DEBUG
+        // Simulator 検証用: launch argument で EEA 地域を強制する
+        if ProcessInfo.processInfo.arguments.contains("-UMPDebugGeographyEEA") {
+            let debugSettings = DebugSettings()
+            debugSettings.geography = .EEA
+            parameters.debugSettings = debugSettings
+        }
+        #endif
+
+        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { updateError in
+            if let updateError {
+                completion(updateError)
+                return
+            }
+            DispatchQueue.main.async {
+                ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
+                    completion(formError)
+                }
+            }
+        }
+    }
+}
+
+/// ATT (App Tracking Transparency) の許可リクエスト。
+/// 既に許可/拒否済み (.notDetermined 以外) の場合はダイアログなしで即 completion が呼ばれる。
+final class ATTAuthorizer: TrackingAuthorizer {
+    func requestAuthorization(completion: @escaping () -> Void) {
+        ATTrackingManager.requestTrackingAuthorization { _ in
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+}
+
+final class GADAdsStarter: AdsStarter {
+    func startAds() {
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+    }
+}

--- a/app/LeafTimer/Components/AdsConsentServices.swift
+++ b/app/LeafTimer/Components/AdsConsentServices.swift
@@ -26,11 +26,15 @@ final class UMPConsentService: ConsentService {
 
         ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { updateError in
             if let updateError {
-                completion(updateError)
+                DispatchQueue.main.async {
+                    completion(updateError)
+                }
                 return
             }
             DispatchQueue.main.async {
-                ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
+                // onboarding の fullScreenCover 等が root を占有していても提示できるよう
+                // 最前面の presented VC から同意フォームを提示する
+                ConsentForm.loadAndPresentIfRequired(from: viewController?.topPresentedViewController) { formError in
                     completion(formError)
                 }
             }
@@ -53,5 +57,16 @@ final class ATTAuthorizer: TrackingAuthorizer {
 final class GADAdsStarter: AdsStarter {
     func startAds() {
         GADMobileAds.sharedInstance().start(completionHandler: nil)
+    }
+}
+
+private extension UIViewController {
+    /// presentedViewController チェーンの最前面 (何も提示していなければ self)
+    var topPresentedViewController: UIViewController {
+        var top: UIViewController = self
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        return top
     }
 }

--- a/app/LeafTimer/Info.plist
+++ b/app/LeafTimer/Info.plist
@@ -20,10 +20,14 @@
 	<string>24</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-9706471521661305~4450977179</string>
+	<key>GADDelayAppMeasurementInit</key>
+	<true/>
 	<key>GADIsAdManagerApp</key>
 	<string>true</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>This identifier will be used to deliver personalized ads to you.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>SKAdNetworkItems</key>

--- a/app/LeafTimer/View/AdsView.swift
+++ b/app/LeafTimer/View/AdsView.swift
@@ -1,12 +1,23 @@
 import GoogleMobileAds
 import SwiftUI
 
-struct AdsView: UIViewRepresentable {
+struct AdsView: View {
+    @ObservedObject private var adsBootstrapper = AdsBootstrapper.shared
+
+    var body: some View {
+        if adsBootstrapper.isAdsStarted {
+            AdsBannerView()
+        } else {
+            Color.clear
+        }
+    }
+}
+
+private struct AdsBannerView: UIViewRepresentable {
     func makeUIView(context: Context) -> GADBannerView {
         let banner = GADBannerView(adSize: GADAdSizeBanner)
 
         banner.adUnitID = KeyManager().getAdUnitID()
-        print(banner.adUnitID)
         // iOS 17対応: windowSceneから適切なrootViewControllerを取得
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
             banner.rootViewController = windowScene.windows.first?.rootViewController

--- a/app/LeafTimerTests/AdsBootstrapperTests.swift
+++ b/app/LeafTimerTests/AdsBootstrapperTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import LeafTimer
+
+final class AdsBootstrapperTests: XCTestCase {
+    private var consent: SpyConsentService!
+    private var tracking: SpyTrackingAuthorizer!
+    private var ads: SpyAdsStarter!
+    private var bootstrapper: AdsBootstrapper!
+
+    override func setUp() {
+        super.setUp()
+        callOrder = []
+        consent = SpyConsentService()
+        tracking = SpyTrackingAuthorizer()
+        ads = SpyAdsStarter()
+        consent.onGather = { [weak self] in self?.callOrder.append("consent") }
+        tracking.onRequest = { [weak self] in self?.callOrder.append("att") }
+        ads.onStart = { [weak self] in self?.callOrder.append("start") }
+        bootstrapper = AdsBootstrapper(
+            consentService: consent,
+            trackingAuthorizer: tracking,
+            adsStarter: ads
+        )
+    }
+
+    func testBootstrapRunsConsentThenATTThenStartsAds() {
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(consent.gatherCallCount, 1)
+        XCTAssertEqual(tracking.requestCallCount, 1)
+        XCTAssertEqual(ads.startCallCount, 1)
+        // 順序: 同意 → ATT → start
+        XCTAssertEqual(callOrder, ["consent", "att", "start"])
+        XCTAssertTrue(bootstrapper.isAdsStarted)
+    }
+
+    func testBootstrapDoesNotStartAdsWhenConsentDisallows() {
+        consent.canRequestAds = false
+
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(ads.startCallCount, 0)
+        XCTAssertFalse(bootstrapper.isAdsStarted)
+        // ATT の許可リクエスト自体は同意結果と独立に 1 回行う
+        XCTAssertEqual(tracking.requestCallCount, 1)
+    }
+
+    func testBootstrapStartsAdsOnConsentErrorIfCachedConsentAllows() {
+        // UMP はネットワークエラー時でも前回セッションの同意が cache されており
+        // canRequestAds が true のままのことがある。その場合は start して良い
+        consent.gatherError = DummyError.network
+        consent.canRequestAds = true
+
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(ads.startCallCount, 1)
+        XCTAssertTrue(bootstrapper.isAdsStarted)
+    }
+
+    func testBootstrapIsIdempotent() {
+        bootstrapper.bootstrap(from: nil, completion: nil)
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(consent.gatherCallCount, 1)
+        XCTAssertEqual(ads.startCallCount, 1)
+    }
+
+    func testBootstrapCallsCompletionAfterFlow() {
+        var completed = false
+        bootstrapper.bootstrap(from: nil) { completed = true }
+        XCTAssertTrue(completed)
+    }
+
+    // MARK: - Spies
+
+    private var callOrder: [String] = []
+
+    private enum DummyError: Error { case network }
+
+    private final class SpyConsentService: ConsentService {
+        var canRequestAds = true
+        var gatherError: Error?
+        private(set) var gatherCallCount = 0
+        var onGather: (() -> Void)?
+
+        func gatherConsent(
+            from viewController: UIViewController?,
+            completion: @escaping (Error?) -> Void
+        ) {
+            gatherCallCount += 1
+            onGather?()
+            completion(gatherError)
+        }
+    }
+
+    private final class SpyTrackingAuthorizer: TrackingAuthorizer {
+        private(set) var requestCallCount = 0
+        var onRequest: (() -> Void)?
+
+        func requestAuthorization(completion: @escaping () -> Void) {
+            requestCallCount += 1
+            onRequest?()
+            completion()
+        }
+    }
+
+    private final class SpyAdsStarter: AdsStarter {
+        private(set) var startCallCount = 0
+        var onStart: (() -> Void)?
+
+        func startAds() {
+            startCallCount += 1
+            onStart?()
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-18-gdpr-ump-att.md
+++ b/docs/superpowers/plans/2026-07-18-gdpr-ump-att.md
@@ -1,0 +1,607 @@
+# GDPR 同意 (UMP) + ATT 対応 Implementation Plan (Issue #57)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** AdMob の広告リクエスト前に UMP (User Messaging Platform) の同意フローと ATT (App Tracking Transparency) の許可リクエストを挟み、EEA/UK ポリシー違反による配信停止リスクを解消する。
+
+**Architecture:** UMP / ATT / GADMobileAds への依存を 3 つの protocol (`ConsentService` / `TrackingAuthorizer` / `AdsStarter`) で抽象化し、「同意取得 → ATT → 広告 SDK start」の順序制御を `AdsBootstrapper` (ObservableObject) に集約する。`AppDelegate` は起動時の即時 `GADMobileAds.start` をやめて bootstrap 呼び出しに置き換え、`AdsView` は `isAdsStarted` が立つまでバナーを生成しない。オーケストレーション部分は spy 注入で unit test し、SDK ラッパーは薄く保ってビルド + Simulator 手動検証で担保する。
+
+**Tech Stack:** Swift / SwiftUI, GoogleUserMessagingPlatform 3.0.0 (CocoaPods 導入済み・未使用), Google-Mobile-Ads-SDK 11.13.0, AppTrackingTransparency (iOS 17.0 deployment target なので availability ガード不要), XCTest (新規テストは Quick/Nimble ではなく XCTest — 直近の OnboardingGateTests 等の流儀に合わせる)
+
+## Global Constraints
+
+- default branch は `master`。作業ブランチは `feature/57-gdpr-ump-att`
+- テスト実行: `cd app && make unit-tests` (Bash timeout は 600000ms を明示)。成否は exit code ではなく出力の `** TEST SUCCEEDED **` / `** TEST FAILED **` マーカーで判定する (zsh のため `${PIPESTATUS[0]}` は使用禁止。`| tail` する時は `set -o pipefail` を前置)
+- 新規 Swift ファイルは必ず `cd app && ruby bin/add-to-target.rb LeafTimer.xcodeproj <file> <target> <group>` で target に attach する (attach 漏れは silent にビルド対象外になる)
+- 新規ファイル追加後は `cd app && make precheck` で orphan 検証、最終 commit 前に `cd app && make sort && git status` を実行する
+- `print()` 追加禁止 (既存 `AdsView.swift:9` の print は Issue #70 スコープなので触らない)
+- 旧 `SettingView.swift` は dead code (Issue #72 で削除予定)。本 plan では**修正対象にしない** (AdsView の呼び出し側 API を変えないことで無修正のままコンパイルを維持する)
+- **UMP 3.0.0 Swift API 名の注意**: v3.0 で Swift 名から `UMP` prefix が外れている想定で本 plan は新名称 (`ConsentInformation` 等) を使う。ビルドで `cannot find 'ConsentInformation' in scope` が出た場合は以下の対応表で旧名称に置換する (逆方向も同様):
+
+| 新名称 (v3.0 Swift) | 旧名称 (UMP prefix) |
+| --- | --- |
+| `ConsentInformation.shared` | `UMPConsentInformation.sharedInstance` |
+| `ConsentForm.loadAndPresentIfRequired(from:completionHandler:)` | `UMPConsentForm.loadAndPresentIfRequired(from:completionHandler:)` |
+| `ConsentRequestParameters` | `UMPRequestParameters` |
+| `ConsentDebugSettings` | `UMPDebugSettings` |
+| `DebugGeography.EEA` | `UMPDebugGeography.EEA` |
+
+---
+
+## Task 0: Plan commit
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-07-18-gdpr-ump-att.md` (this file)
+
+- [ ] **Step 1: ブランチ確認と plan の commit**
+
+```bash
+git checkout feature/57-gdpr-ump-att
+git add docs/superpowers/plans/2026-07-18-gdpr-ump-att.md
+git commit -m "docs(plan): #57 GDPR 同意 (UMP) + ATT 対応の実装 plan"
+```
+
+---
+
+## Task 1: AdsBootstrapper — 同意→ATT→広告開始のオーケストレータ (TDD)
+
+**Files:**
+- Create: `app/LeafTimer/Components/AdsBootstrapper.swift`
+- Test: `app/LeafTimerTests/AdsBootstrapperTests.swift`
+
+**Interfaces:**
+- Produces (後続 Task が依存する契約):
+  - `protocol ConsentService { var canRequestAds: Bool { get }; func gatherConsent(from viewController: UIViewController?, completion: @escaping (Error?) -> Void) }`
+  - `protocol TrackingAuthorizer { func requestAuthorization(completion: @escaping () -> Void) }`
+  - `protocol AdsStarter { func startAds() }`
+  - `final class AdsBootstrapper: ObservableObject` — `static let shared`, `@Published private(set) var isAdsStarted: Bool`, `init(consentService:trackingAuthorizer:adsStarter:)`, `func bootstrap(from viewController: UIViewController?, completion: (() -> Void)?)`
+  - `AdsBootstrapper.shared` は Task 2 で作る実装クラス (`UMPConsentService()` / `ATTAuthorizer()` / `GADAdsStarter()`) をデフォルト引数で使う。**Task 1 の時点では実装クラスが未定なので、`shared` とデフォルト引数は Task 2 で追加する** (Task 1 では明示 init のみ)
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/LeafTimerTests/AdsBootstrapperTests.swift` を以下の内容で作成:
+
+```swift
+import XCTest
+@testable import LeafTimer
+
+final class AdsBootstrapperTests: XCTestCase {
+    private var consent: SpyConsentService!
+    private var tracking: SpyTrackingAuthorizer!
+    private var ads: SpyAdsStarter!
+    private var bootstrapper: AdsBootstrapper!
+
+    override func setUp() {
+        super.setUp()
+        callOrder = []
+        consent = SpyConsentService()
+        tracking = SpyTrackingAuthorizer()
+        ads = SpyAdsStarter()
+        consent.onGather = { [weak self] in self?.callOrder.append("consent") }
+        tracking.onRequest = { [weak self] in self?.callOrder.append("att") }
+        ads.onStart = { [weak self] in self?.callOrder.append("start") }
+        bootstrapper = AdsBootstrapper(
+            consentService: consent,
+            trackingAuthorizer: tracking,
+            adsStarter: ads
+        )
+    }
+
+    func testBootstrapRunsConsentThenATTThenStartsAds() {
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(consent.gatherCallCount, 1)
+        XCTAssertEqual(tracking.requestCallCount, 1)
+        XCTAssertEqual(ads.startCallCount, 1)
+        // 順序: 同意 → ATT → start
+        XCTAssertEqual(callOrder, ["consent", "att", "start"])
+        XCTAssertTrue(bootstrapper.isAdsStarted)
+    }
+
+    func testBootstrapDoesNotStartAdsWhenConsentDisallows() {
+        consent.canRequestAds = false
+
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(ads.startCallCount, 0)
+        XCTAssertFalse(bootstrapper.isAdsStarted)
+        // ATT の許可リクエスト自体は同意結果と独立に 1 回行う
+        XCTAssertEqual(tracking.requestCallCount, 1)
+    }
+
+    func testBootstrapStartsAdsOnConsentErrorIfCachedConsentAllows() {
+        // UMP はネットワークエラー時でも前回セッションの同意が cache されており
+        // canRequestAds が true のままのことがある。その場合は start して良い
+        consent.gatherError = DummyError.network
+        consent.canRequestAds = true
+
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(ads.startCallCount, 1)
+        XCTAssertTrue(bootstrapper.isAdsStarted)
+    }
+
+    func testBootstrapIsIdempotent() {
+        bootstrapper.bootstrap(from: nil, completion: nil)
+        bootstrapper.bootstrap(from: nil, completion: nil)
+
+        XCTAssertEqual(consent.gatherCallCount, 1)
+        XCTAssertEqual(ads.startCallCount, 1)
+    }
+
+    func testBootstrapCallsCompletionAfterFlow() {
+        var completed = false
+        bootstrapper.bootstrap(from: nil) { completed = true }
+        XCTAssertTrue(completed)
+    }
+
+    // MARK: - Spies
+
+    private var callOrder: [String] = []
+
+    private enum DummyError: Error { case network }
+
+    private final class SpyConsentService: ConsentService {
+        var canRequestAds = true
+        var gatherError: Error?
+        private(set) var gatherCallCount = 0
+        var onGather: (() -> Void)?
+
+        func gatherConsent(
+            from viewController: UIViewController?,
+            completion: @escaping (Error?) -> Void
+        ) {
+            gatherCallCount += 1
+            onGather?()
+            completion(gatherError)
+        }
+    }
+
+    private final class SpyTrackingAuthorizer: TrackingAuthorizer {
+        private(set) var requestCallCount = 0
+        var onRequest: (() -> Void)?
+
+        func requestAuthorization(completion: @escaping () -> Void) {
+            requestCallCount += 1
+            onRequest?()
+            completion()
+        }
+    }
+
+    private final class SpyAdsStarter: AdsStarter {
+        private(set) var startCallCount = 0
+        var onStart: (() -> Void)?
+
+        func startAds() {
+            startCallCount += 1
+            onStart?()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: テストファイルを test target に attach**
+
+```bash
+cd app && ruby bin/add-to-target.rb LeafTimer.xcodeproj LeafTimerTests/AdsBootstrapperTests.swift LeafTimerTests LeafTimerTests
+```
+
+- [ ] **Step 3: RED を確認する**
+
+Run (timeout 600000ms):
+
+```bash
+cd app && set -o pipefail && make unit-tests 2>&1 | tail -40
+```
+
+Expected: **ビルド失敗** — `cannot find type 'ConsentService' in scope` (および `AdsBootstrapper` 未定義)。コンパイルエラーによる RED であることを確認する。テストが誤って green なら手を止めて原因調査。
+
+- [ ] **Step 4: 最小実装を書く**
+
+`app/LeafTimer/Components/AdsBootstrapper.swift` を以下の内容で作成:
+
+```swift
+import Foundation
+import UIKit
+
+protocol ConsentService {
+    var canRequestAds: Bool { get }
+    func gatherConsent(
+        from viewController: UIViewController?,
+        completion: @escaping (Error?) -> Void
+    )
+}
+
+protocol TrackingAuthorizer {
+    func requestAuthorization(completion: @escaping () -> Void)
+}
+
+protocol AdsStarter {
+    func startAds()
+}
+
+/// 広告表示前の同意フローを統括する。
+/// 順序: UMP 同意取得 → ATT 許可リクエスト → (同意 OK なら) GADMobileAds start
+final class AdsBootstrapper: ObservableObject {
+    @Published private(set) var isAdsStarted = false
+
+    private let consentService: ConsentService
+    private let trackingAuthorizer: TrackingAuthorizer
+    private let adsStarter: AdsStarter
+    private var isBootstrapping = false
+
+    init(
+        consentService: ConsentService,
+        trackingAuthorizer: TrackingAuthorizer,
+        adsStarter: AdsStarter
+    ) {
+        self.consentService = consentService
+        self.trackingAuthorizer = trackingAuthorizer
+        self.adsStarter = adsStarter
+    }
+
+    func bootstrap(from viewController: UIViewController?, completion: (() -> Void)?) {
+        guard !isAdsStarted, !isBootstrapping else {
+            completion?()
+            return
+        }
+        isBootstrapping = true
+
+        // UMP がエラーを返しても前回セッションの cached 同意で
+        // canRequestAds が立ち得るため、エラーでもフローは継続する
+        consentService.gatherConsent(from: viewController) { [weak self] _ in
+            self?.trackingAuthorizer.requestAuthorization {
+                guard let self else { return }
+                self.isBootstrapping = false
+                if self.consentService.canRequestAds {
+                    self.adsStarter.startAds()
+                    self.isAdsStarted = true
+                }
+                completion?()
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: 実装ファイルを app target に attach**
+
+```bash
+cd app && ruby bin/add-to-target.rb LeafTimer.xcodeproj LeafTimer/Components/AdsBootstrapper.swift LeafTimer LeafTimer/Components
+```
+
+- [ ] **Step 6: GREEN を確認する**
+
+Run (timeout 600000ms):
+
+```bash
+cd app && set -o pipefail && make unit-tests 2>&1 | tail -40
+```
+
+Expected: `** TEST SUCCEEDED **` が出力に含まれる。AdsBootstrapperTests の 5 テスト全て pass。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/LeafTimer/Components/AdsBootstrapper.swift app/LeafTimerTests/AdsBootstrapperTests.swift app/LeafTimer.xcodeproj/project.pbxproj
+git commit -m "feat(ads): #57 同意フローを統括する AdsBootstrapper を TDD で追加"
+```
+
+---
+
+## Task 2: SDK ラッパー実装 (UMPConsentService / ATTAuthorizer / GADAdsStarter)
+
+**Files:**
+- Create: `app/LeafTimer/Components/AdsConsentServices.swift`
+- Modify: `app/LeafTimer/Components/AdsBootstrapper.swift` (shared singleton + デフォルト引数の追加)
+
+**Interfaces:**
+- Consumes: Task 1 の `ConsentService` / `TrackingAuthorizer` / `AdsStarter` protocol
+- Produces: `UMPConsentService` / `ATTAuthorizer` / `GADAdsStarter` (いずれも上記 protocol 準拠)、`AdsBootstrapper.shared` (Task 3 の AppDelegate / AdsView が使用)
+
+薄い SDK ラッパーで分岐ロジックを持たないため unit test は書かない (オーケストレーションは Task 1 でテスト済み)。ビルド成立 + Task 4 の Simulator 手動検証で担保する。
+
+- [ ] **Step 1: SDK ラッパーを書く**
+
+`app/LeafTimer/Components/AdsConsentServices.swift` を以下の内容で作成 (ビルドエラー時は Global Constraints の API 対応表で旧名称に置換):
+
+```swift
+import AppTrackingTransparency
+import GoogleMobileAds
+import UIKit
+import UserMessagingPlatform
+
+/// UMP (User Messaging Platform) による GDPR 同意取得。
+/// EEA/UK 以外の地域では form 提示不要と判定され、そのまま completion が呼ばれる。
+final class UMPConsentService: ConsentService {
+    var canRequestAds: Bool {
+        ConsentInformation.shared.canRequestAds
+    }
+
+    func gatherConsent(
+        from viewController: UIViewController?,
+        completion: @escaping (Error?) -> Void
+    ) {
+        let parameters = ConsentRequestParameters()
+        #if DEBUG
+        // Simulator 検証用: launch argument で EEA 地域を強制する
+        if ProcessInfo.processInfo.arguments.contains("-UMPDebugGeographyEEA") {
+            let debugSettings = ConsentDebugSettings()
+            debugSettings.geography = .EEA
+            parameters.debugSettings = debugSettings
+        }
+        #endif
+
+        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { updateError in
+            if let updateError {
+                completion(updateError)
+                return
+            }
+            DispatchQueue.main.async {
+                ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
+                    completion(formError)
+                }
+            }
+        }
+    }
+}
+
+/// ATT (App Tracking Transparency) の許可リクエスト。
+/// 既に許可/拒否済み (.notDetermined 以外) の場合はダイアログなしで即 completion が呼ばれる。
+final class ATTAuthorizer: TrackingAuthorizer {
+    func requestAuthorization(completion: @escaping () -> Void) {
+        ATTrackingManager.requestTrackingAuthorization { _ in
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+}
+
+final class GADAdsStarter: AdsStarter {
+    func startAds() {
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+    }
+}
+```
+
+注意: `import UserMessagingPlatform` がモジュール名。`No such module` になる場合は `import GoogleUserMessagingPlatform` を試す。
+
+- [ ] **Step 2: AdsBootstrapper に shared とデフォルト引数を追加**
+
+`app/LeafTimer/Components/AdsBootstrapper.swift` の `init` を以下に置換し、`static let shared` を追加:
+
+```swift
+    static let shared = AdsBootstrapper()
+
+    init(
+        consentService: ConsentService = UMPConsentService(),
+        trackingAuthorizer: TrackingAuthorizer = ATTAuthorizer(),
+        adsStarter: AdsStarter = GADAdsStarter()
+    ) {
+        self.consentService = consentService
+        self.trackingAuthorizer = trackingAuthorizer
+        self.adsStarter = adsStarter
+    }
+```
+
+- [ ] **Step 3: ファイルを app target に attach**
+
+```bash
+cd app && ruby bin/add-to-target.rb LeafTimer.xcodeproj LeafTimer/Components/AdsConsentServices.swift LeafTimer LeafTimer/Components
+```
+
+- [ ] **Step 4: ビルド + 既存テスト green を確認**
+
+Run (timeout 600000ms):
+
+```bash
+cd app && set -o pipefail && make unit-tests 2>&1 | tail -40
+```
+
+Expected: `** TEST SUCCEEDED **`。API 名エラーが出た場合は Global Constraints の対応表で置換して再実行。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/LeafTimer/Components/AdsConsentServices.swift app/LeafTimer/Components/AdsBootstrapper.swift app/LeafTimer.xcodeproj/project.pbxproj
+git commit -m "feat(ads): #57 UMP/ATT/GADMobileAds の実装ラッパーを追加"
+```
+
+---
+
+## Task 3: 配線 — AppDelegate / AdsView / Info.plist / InfoPlist.strings
+
+**Files:**
+- Modify: `app/LeafTimer/App/AppDelegate.swift:20` (即時 start の除去) / `:39` 直後 (bootstrap 呼び出し)
+- Modify: `app/LeafTimer/View/AdsView.swift` (同意完了までバナー非生成)
+- Modify: `app/LeafTimer/Info.plist` (`NSUserTrackingUsageDescription` + `GADDelayAppMeasurementInit`)
+- Modify: `app/LeafTimer/App/ja.lproj/InfoPlist.strings` / `app/LeafTimer/App/en.lproj/InfoPlist.strings`
+
+**Interfaces:**
+- Consumes: `AdsBootstrapper.shared` / `.isAdsStarted` / `.bootstrap(from:completion:)` (Task 1–2)
+
+- [ ] **Step 1: AppDelegate から即時 start を除去し bootstrap に置換**
+
+`app/LeafTimer/App/AppDelegate.swift` の
+
+```swift
+        FirebaseApp.configure()
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+```
+
+を
+
+```swift
+        FirebaseApp.configure()
+        // GADMobileAds の start は UMP 同意 + ATT 完了後に AdsBootstrapper が行う (#57)
+```
+
+に置換し、`window?.makeKeyAndVisible()` の直後に以下を追加:
+
+```swift
+        // 同意フォーム/ATT ダイアログの提示は app active 後である必要があるため
+        // 起動処理完了後の main queue で開始する
+        DispatchQueue.main.async { [weak self] in
+            AdsBootstrapper.shared.bootstrap(
+                from: self?.window?.rootViewController,
+                completion: nil
+            )
+        }
+```
+
+- [ ] **Step 2: AdsView を同意ゲート付きに変更**
+
+`app/LeafTimer/View/AdsView.swift` の `AdsView` struct 全体 (1〜21 行目の `import` 2 行と `AdsView`) を以下に置換する。呼び出し側 (`EnhancedSettingView.swift:94` と dead な `SettingView.swift:74`) は `AdsView().frame(...)` のままなので**変更不要**:
+
+```swift
+import GoogleMobileAds
+import SwiftUI
+
+struct AdsView: View {
+    @ObservedObject private var adsBootstrapper = AdsBootstrapper.shared
+
+    var body: some View {
+        if adsBootstrapper.isAdsStarted {
+            AdsBannerView()
+        } else {
+            Color.clear
+        }
+    }
+}
+
+private struct AdsBannerView: UIViewRepresentable {
+    func makeUIView(context: Context) -> GADBannerView {
+        let banner = GADBannerView(adSize: GADAdSizeBanner)
+
+        banner.adUnitID = KeyManager().getAdUnitID()
+        // iOS 17対応: windowSceneから適切なrootViewControllerを取得
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            banner.rootViewController = windowScene.windows.first?.rootViewController
+        }
+
+        let request = GADRequest()
+        banner.load(request)
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {}
+}
+```
+
+注意: 既存の `print(banner.adUnitID)` (旧 9 行目) はこの置換で消える。これは Issue #70 スコープの print 削除を先取りするのではなく、`AdsBannerView` へ移設する際に持ち込まない判断 (新規コードに print 追加禁止)。ファイル末尾の dead な `ContentView` / `ContentView_Previews` は触らない (Issue #72 スコープ)。
+
+- [ ] **Step 3: Info.plist にキーを追加**
+
+`app/LeafTimer/Info.plist` の `<key>GADIsAdManagerApp</key>` の手前に以下を追加:
+
+```xml
+	<key>GADDelayAppMeasurementInit</key>
+	<true/>
+```
+
+`<key>LSRequiresIPhoneOS</key>` の手前 (アルファベット順で N の位置) に以下を追加:
+
+```xml
+	<key>NSUserTrackingUsageDescription</key>
+	<string>This identifier will be used to deliver personalized ads to you.</string>
+```
+
+`GADDelayAppMeasurementInit` は「明示的に start を呼ぶまで SDK の計測初期化を遅延させる」キーで、start を同意後に遅延させた本対応とセットで必要。
+
+- [ ] **Step 4: InfoPlist.strings に ATT 文言のローカライズを追加**
+
+`app/LeafTimer/App/ja.lproj/InfoPlist.strings` の末尾に追加:
+
+```text
+"NSUserTrackingUsageDescription" = "広告配信を最適化するために識別子を使用します。";
+```
+
+`app/LeafTimer/App/en.lproj/InfoPlist.strings` の末尾に追加:
+
+```text
+"NSUserTrackingUsageDescription" = "This identifier will be used to deliver personalized ads to you.";
+```
+
+- [ ] **Step 5: ビルド + 既存テスト green を確認**
+
+Run (timeout 600000ms):
+
+```bash
+cd app && set -o pipefail && make unit-tests 2>&1 | tail -40
+```
+
+Expected: `** TEST SUCCEEDED **`。既存の View 系 Spec (TimerViewSpec / ModernSettingViewSpec 等) が AdsView の構造変更で fail していないことを確認する。fail した場合は当該 Spec が `AdsView` の内部構造 (UIViewRepresentable であること) に依存していないか読み、依存があればテスト側を `AdsView` の新構造に合わせて更新する。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/LeafTimer/App/AppDelegate.swift app/LeafTimer/View/AdsView.swift app/LeafTimer/Info.plist app/LeafTimer/App/ja.lproj/InfoPlist.strings app/LeafTimer/App/en.lproj/InfoPlist.strings
+git commit -m "feat(ads): #57 起動時の広告初期化を同意フロー完了後に遅延し ATT 文言を追加"
+```
+
+---
+
+## Task 4: Simulator 手動検証 + 仕上げ (sort / precheck / PR)
+
+**Files:**
+- Modify (必要時のみ): 検証で発覚した不具合の修正
+
+- [ ] **Step 1: EEA 同意フォームの表示を Simulator で検証**
+
+REQUIRED SUB-SKILL: `ios-simulator-app-verification` の boot/build/install/launch/screenshot サイクルに従う。検証ポイント:
+
+1. `-UMPDebugGeographyEEA` launch argument 付きで起動 → **UMP 同意フォームが表示される**こと (スクリーンショット取得)
+2. フォームで同意 → **ATT ダイアログが表示される**こと (スクリーンショット取得)。Simulator の 設定 > プライバシーとセキュリティ > トラッキング で「Appからのトラッキング要求を許可」が OFF だと ATT ダイアログは表示されずに即 denied になる。その場合は ON にしてアプリを削除→再インストールして再検証
+3. 同意完了後、設定画面 (歯車アイコン) を開いて**バナー枠が表示される**こと
+4. launch argument なし (日本地域) で削除→再インストール起動 → 同意フォームは出ず、ATT ダイアログのみ表示され、バナーが従来どおり表示されること
+5. 再起動 2 回目以降はダイアログ類が一切出ないこと (UMP cache + ATT 決定済み)
+
+再検証時の同意リセットはアプリ削除 (`xcrun simctl uninstall <SIM> <bundle-id>`) で行う。
+
+- [ ] **Step 2: 最終チェック**
+
+```bash
+cd app && make precheck && make sort && git status
+```
+
+Expected: precheck pass (新規 2 ファイルの orphan なし)、sort 後の `git status` で差分が出た場合は pbxproj を追加 commit:
+
+```bash
+git add app/LeafTimer.xcodeproj/project.pbxproj
+git commit -m "chore: #57 project.pbxproj の children グループをソート"
+```
+
+- [ ] **Step 3: フルテスト**
+
+Run (timeout 600000ms):
+
+```bash
+cd app && set -o pipefail && make tests 2>&1 | tail -40
+```
+
+Expected: `** TEST SUCCEEDED **` (precheck / sort / lint / unit-tests 全て pass)
+
+- [ ] **Step 4: Push + PR 作成**
+
+```bash
+git fetch && gh pr list --state all --head feature/57-gdpr-ump-att
+git push -u origin feature/57-gdpr-ump-att
+```
+
+PR 本文には Step 1 のスクリーンショット用の空セクション (「## スクリーンショット」見出しのみ) を用意し、画像ファイルは `SendUserFile` でユーザーに渡してブラウザからドラッグ&ドロップしてもらう (`gh` はローカル画像を embed できない)。
+
+```bash
+gh pr create --title "feat(ads): #57 AdMob の GDPR 同意 (UMP) と ATT を実装" --body "..."
+```
+
+PR 本文に含める内容: Issue #57 へのリンク (`Closes #57`)、同意フローの順序図 (UMP → ATT → start)、検証した 5 パターン (EEA 同意 / EEA 拒否は今回未検証なら明記 / 日本 / 2 回目起動 / バナー表示)、スクリーンショット空セクション。
+
+---
+
+## Self-Review 結果
+
+- **Spec coverage**: Issue #57 の対応方針案 3 点 (UMP consent form 提示 / requestTrackingAuthorization / NSUserTrackingUsageDescription) は Task 2 (UMP/ATT 実装)・Task 3 (plist + 文言) でカバー。追加で GADDelayAppMeasurementInit と起動時 start の遅延 (Task 3)、EEA/非 EEA の Simulator 検証 (Task 4) を含めた
+- **Placeholder scan**: コード全文・コマンド・期待出力を全ステップに記載済み。PR body のみ「...」だが構成要素は列挙済み
+- **Type consistency**: `ConsentService.gatherConsent(from: UIViewController?, ...)` — Task 1 のテスト/実装、Task 2 の UMPConsentService、Task 3 の AppDelegate 呼び出しで optional VC を渡す設計に統一 (テストから `nil` を渡せるようにするため optional)
+- **Path 実在確認**: `app/bin/add-to-target.rb` / `app/Makefile` の `precheck`・`sort`・`unit-tests`・`tests` ターゲット / `AppDelegate.swift:20` / `AdsView.swift` / `Info.plist` / `ja.lproj/en.lproj InfoPlist.strings` / `EnhancedSettingView.swift:94` は全て Read/Glob で確認済み。UMP の Swift API 名のみ Pods が read deny のため未確認 — fallback 表で吸収する

--- a/docs/superpowers/plans/2026-07-18-gdpr-ump-att.md
+++ b/docs/superpowers/plans/2026-07-18-gdpr-ump-att.md
@@ -16,15 +16,15 @@
 - 新規ファイル追加後は `cd app && make precheck` で orphan 検証、最終 commit 前に `cd app && make sort && git status` を実行する
 - `print()` 追加禁止 (既存 `AdsView.swift:9` の print は Issue #70 スコープなので触らない)
 - 旧 `SettingView.swift` は dead code (Issue #72 で削除予定)。本 plan では**修正対象にしない** (AdsView の呼び出し側 API を変えないことで無修正のままコンパイルを維持する)
-- **UMP 3.0.0 Swift API 名の注意**: v3.0 で Swift 名から `UMP` prefix が外れている想定で本 plan は新名称 (`ConsentInformation` 等) を使う。ビルドで `cannot find 'ConsentInformation' in scope` が出た場合は以下の対応表で旧名称に置換する (逆方向も同様):
+- **UMP 3.0.0 Swift API 名 (実装時に確定済み)**: 実ビルドで確定した名称は plan 初版の想定 (`ConsentRequestParameters` 等) とも UMP prefix 版とも異なる第 3 の形だった。コンパイラの rename 診断 (`'UMPRequestParameters' has been renamed to 'RequestParameters'`) で判明:
 
-| 新名称 (v3.0 Swift) | 旧名称 (UMP prefix) |
+| 実際の Swift 名 (v3.0.0) | 備考 |
 | --- | --- |
-| `ConsentInformation.shared` | `UMPConsentInformation.sharedInstance` |
-| `ConsentForm.loadAndPresentIfRequired(from:completionHandler:)` | `UMPConsentForm.loadAndPresentIfRequired(from:completionHandler:)` |
-| `ConsentRequestParameters` | `UMPRequestParameters` |
-| `ConsentDebugSettings` | `UMPDebugSettings` |
-| `DebugGeography.EEA` | `UMPDebugGeography.EEA` |
+| `ConsentInformation.shared` | plan 想定どおり |
+| `ConsentForm.loadAndPresentIfRequired(from:completionHandler:)` | plan 想定どおり |
+| `RequestParameters` | 初版想定 `ConsentRequestParameters` ではない |
+| `DebugSettings` | 初版想定 `ConsentDebugSettings` ではない |
+| `DebugGeography.EEA` | plan 想定どおり |
 
 ---
 


### PR DESCRIPTION
Closes #57

## 概要
広告リクエスト前に UMP (User Messaging Platform) の GDPR 同意フローと ATT (App Tracking Transparency) を挟み、EEA/UK ポリシー違反による配信停止リスクを解消する。

## 同意フローの順序
```
起動 → UMP 同意取得 (requestConsentInfoUpdate → loadAndPresentIfRequired)
     → ATT 許可リクエスト (requestTrackingAuthorization)
     → canRequestAds なら GADMobileAds start → バナー表示
```

- `AdsBootstrapper` (ObservableObject): 順序制御・冪等性・同意拒否時の広告停止を統括。UMP/ATT/GAD は protocol 抽象化し spy 注入で TDD (5 テスト)
- `AppDelegate`: 起動時の即時 `GADMobileAds.start` を除去し bootstrap 呼び出しに置換
- `AdsView`: `isAdsStarted` が立つまでバナーを生成しない同意ゲート化 (呼び出し側 API は不変)
- `Info.plist`: `NSUserTrackingUsageDescription` (ja/en ローカライズ込み) + `GADDelayAppMeasurementInit`
- 同意フォームは最前面の presented VC から提示 (onboarding の fullScreenCover との presentation 競合を回避)

## Simulator 検証 (iPhone 17 / iOS 26)
| 項目 | 結果 |
|---|---|
| EEA (`-UMPDebugGeographyEEA`): UMP リクエスト発火 → ATT の順序 | ✅ ログで確認 |
| ATT ダイアログ表示 + ja 文言 | ✅ スクショ |
| 日本パス: ダイアログなしで起動・2回目起動もダイアログなし | ✅ スクショ |
| 同意フロー完了後のバナー表示 (テスト広告) | ✅ スクショ |
| EEA の UMP 同意フォーム表示 | ⏸ AdMob コンソールに GDPR メッセージ未作成のため未検証 → #90 で対応 (真の初回起動 × EEA の再検証手順も #90 に記載) |

## テスト
`make tests` (precheck + sort + lint + unit-tests) → `** TEST SUCCEEDED **` 151 tests / 0 failures

## レビュー
task review (spec ✅ / quality Approved) + 最終 whole-branch review 実施済み。Important 指摘 1 件 (presentation 競合) は 21e4ad1 で修正し再レビューで Resolved 判定。

## スクリーンショット
<!-- ブラウザからドラッグ&ドロップで添付してください -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azz51haxn4qXYVbKUvoz2r